### PR TITLE
feat(nvml): enhance GPU inventory with extended NVML data

### DIFF
--- a/pkg/nvml/interface.go
+++ b/pkg/nvml/interface.go
@@ -113,17 +113,67 @@ type Utilization struct {
 
 // GPUInfo is a consolidated view of GPU device information.
 type GPUInfo struct {
-	Index       int
-	Name        string
-	UUID        string
-	BusID       string
-	MemoryTotal uint64
-	MemoryUsed  uint64
-	MemoryFree  uint64
-	Temperature uint32
-	PowerUsage  uint32
-	GPUUtil     uint32
-	MemoryUtil  uint32
+	Index int    `json:"index"`
+	Name  string `json:"name"`
+	UUID  string `json:"uuid"`
+	BusID string `json:"bus_id"`
+
+	// Memory information
+	Memory MemorySpec `json:"memory"`
+
+	// Temperature with thresholds
+	Temperature TempSpec `json:"temperature"`
+
+	// Power with limits
+	Power PowerSpec `json:"power"`
+
+	// Clock frequencies
+	Clocks ClockSpec `json:"clocks"`
+
+	// Utilization rates
+	Utilization UtilSpec `json:"utilization"`
+
+	// ECC status (nil if not supported)
+	ECC *ECCSpec `json:"ecc,omitempty"`
+}
+
+// MemorySpec contains memory capacity information.
+type MemorySpec struct {
+	TotalBytes uint64 `json:"total_bytes"`
+	UsedBytes  uint64 `json:"used_bytes"`
+	FreeBytes  uint64 `json:"free_bytes"`
+}
+
+// TempSpec contains temperature with thresholds.
+type TempSpec struct {
+	CurrentCelsius  uint32 `json:"current_celsius"`
+	SlowdownCelsius uint32 `json:"slowdown_celsius"`
+	ShutdownCelsius uint32 `json:"shutdown_celsius"`
+}
+
+// PowerSpec contains power usage and limits.
+type PowerSpec struct {
+	CurrentMW uint32 `json:"current_mw"`
+	LimitMW   uint32 `json:"limit_mw"`
+}
+
+// ClockSpec contains clock frequencies.
+type ClockSpec struct {
+	SMMHZ     uint32 `json:"sm_mhz"`
+	MemoryMHZ uint32 `json:"memory_mhz"`
+}
+
+// UtilSpec contains utilization rates.
+type UtilSpec struct {
+	GPUPercent    uint32 `json:"gpu_percent"`
+	MemoryPercent uint32 `json:"memory_percent"`
+}
+
+// ECCSpec contains ECC memory status.
+type ECCSpec struct {
+	Enabled             bool   `json:"enabled"`
+	CorrectableErrors   uint64 `json:"correctable_errors"`
+	UncorrectableErrors uint64 `json:"uncorrectable_errors"`
 }
 
 // ThrottleReason constants for interpreting GetCurrentClocksThrottleReasons.

--- a/pkg/tools/gpu_inventory_test.go
+++ b/pkg/tools/gpu_inventory_test.go
@@ -52,12 +52,18 @@ func TestGPUInventoryHandler_Handle(t *testing.T) {
 				require.True(t, ok)
 				assert.Len(t, devices, 2)
 
-				// Check first device has expected fields
+				// Check first device has expected fields (snake_case JSON)
 				device0 := devices[0].(map[string]interface{})
-				assert.Contains(t, device0, "Index")
-				assert.Contains(t, device0, "Name")
-				assert.Contains(t, device0, "UUID")
-				assert.Contains(t, device0, "BusID")
+				assert.Contains(t, device0, "index")
+				assert.Contains(t, device0, "name")
+				assert.Contains(t, device0, "uuid")
+				assert.Contains(t, device0, "bus_id")
+				assert.Contains(t, device0, "memory")
+				assert.Contains(t, device0, "temperature")
+				assert.Contains(t, device0, "power")
+				assert.Contains(t, device0, "clocks")
+				assert.Contains(t, device0, "utilization")
+				assert.Contains(t, device0, "ecc")
 			},
 		},
 		{
@@ -151,18 +157,71 @@ func TestGPUInventoryHandler_collectDeviceInfo(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, info)
 
-	// Verify all fields are populated
+	// Verify basic fields
 	assert.Equal(t, 0, info.Index)
 	assert.NotEmpty(t, info.Name)
 	assert.Contains(t, info.Name, "NVIDIA")
 	assert.NotEmpty(t, info.UUID)
 	assert.Contains(t, info.UUID, "GPU-")
 	assert.NotEmpty(t, info.BusID)
-	assert.Greater(t, info.MemoryTotal, uint64(0))
-	assert.Greater(t, info.Temperature, uint32(0))
-	assert.Greater(t, info.PowerUsage, uint32(0))
-	assert.LessOrEqual(t, info.GPUUtil, uint32(100))
-	assert.LessOrEqual(t, info.MemoryUtil, uint32(100))
+
+	// Verify nested memory spec
+	assert.Greater(t, info.Memory.TotalBytes, uint64(0))
+	assert.GreaterOrEqual(t, info.Memory.UsedBytes, uint64(0))
+	assert.Greater(t, info.Memory.FreeBytes, uint64(0))
+
+	// Verify nested temperature spec with thresholds
+	assert.Greater(t, info.Temperature.CurrentCelsius, uint32(0))
+	assert.Greater(t, info.Temperature.SlowdownCelsius, uint32(0))
+	assert.Greater(t, info.Temperature.ShutdownCelsius, uint32(0))
+
+	// Verify nested power spec with limit
+	assert.Greater(t, info.Power.CurrentMW, uint32(0))
+	assert.Greater(t, info.Power.LimitMW, uint32(0))
+
+	// Verify nested clocks spec
+	assert.Greater(t, info.Clocks.SMMHZ, uint32(0))
+	assert.Greater(t, info.Clocks.MemoryMHZ, uint32(0))
+
+	// Verify nested utilization spec
+	assert.LessOrEqual(t, info.Utilization.GPUPercent, uint32(100))
+	assert.LessOrEqual(t, info.Utilization.MemoryPercent, uint32(100))
+
+	// Verify ECC spec (mock has ECC enabled)
+	require.NotNil(t, info.ECC)
+	assert.True(t, info.ECC.Enabled)
+}
+
+func TestGPUInventoryHandler_NestedStructures(t *testing.T) {
+	mockClient := nvml.NewMock(1)
+	handler := NewGPUInventoryHandler(mockClient)
+
+	result, err := handler.Handle(context.Background(), mcp.CallToolRequest{})
+	require.NoError(t, err)
+
+	// Verify JSON structure contains nested objects
+	textContent, ok := mcp.AsTextContent(result.Content[0])
+	require.True(t, ok)
+	responseText := textContent.Text
+
+	// Should have nested objects with snake_case keys
+	assert.Contains(t, responseText, `"memory":`)
+	assert.Contains(t, responseText, `"total_bytes":`)
+	assert.Contains(t, responseText, `"temperature":`)
+	assert.Contains(t, responseText, `"current_celsius":`)
+	assert.Contains(t, responseText, `"slowdown_celsius":`)
+	assert.Contains(t, responseText, `"shutdown_celsius":`)
+	assert.Contains(t, responseText, `"power":`)
+	assert.Contains(t, responseText, `"current_mw":`)
+	assert.Contains(t, responseText, `"limit_mw":`)
+	assert.Contains(t, responseText, `"clocks":`)
+	assert.Contains(t, responseText, `"sm_mhz":`)
+	assert.Contains(t, responseText, `"memory_mhz":`)
+	assert.Contains(t, responseText, `"utilization":`)
+	assert.Contains(t, responseText, `"gpu_percent":`)
+	assert.Contains(t, responseText, `"memory_percent":`)
+	assert.Contains(t, responseText, `"ecc":`)
+	assert.Contains(t, responseText, `"enabled":`)
 }
 
 func TestGetGPUInventoryTool(t *testing.T) {


### PR DESCRIPTION
## Summary

Enhances `get_gpu_inventory` tool to include the new NVML data fields added in the interface extension. This provides a complete hardware specification view for each GPU.

## Changes

- Add 6 new spec types: `MemorySpec`, `TempSpec`, `PowerSpec`, `ClockSpec`, `UtilSpec`, `ECCSpec`
- Restructure `GPUInfo` to use nested types with snake_case JSON tags
- Update `collectDeviceInfo` to use all 6 new NVML methods
- Graceful fallback for optional fields (thresholds, limits, clocks, ECC)
- Update unit tests for new nested JSON structure

## New Output Format

```json
{
  "temperature": {"current_celsius": 28, "slowdown_celsius": 93, "shutdown_celsius": 96},
  "power": {"current_mw": 13837, "limit_mw": 70000},
  "clocks": {"sm_mhz": 300, "memory_mhz": 405},
  "ecc": {"enabled": true, "correctable_errors": 0, "uncorrectable_errors": 0}
}
```

## Testing

- [x] Unit tests pass (`make all`)
- [x] Mock mode tested locally
- [x] Real NVML tested on Tesla T4 (Driver 575.57.08, CUDA 12.9)

## Breaking Change

This modifies the JSON output structure of `get_gpu_inventory`. Since the project is pre-1.0, this clean break is acceptable for cleaner API design.

Closes #TBD