### PR TITLE
chore(cursor): add Go worktree setup configuration

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,11 @@
+{
+  "setup-worktree": [
+    "go mod download",
+    "make build"
+  ],
+  "setup-worktree-unix": [
+    "go mod download",
+    "make build",
+    "make test-short"
+  ]
+}


### PR DESCRIPTION
## Summary

Configure Cursor IDE worktree feature with Go-appropriate setup commands.

- Replace `npm install` with Go equivalents
- Add `go mod download` and `make build` for worktree initialization
- Include `make test-short` for Unix platforms

## Test plan

- [x] Verify worktrees.json syntax is valid JSON
- [ ] Test worktree creation in Cursor IDE