### PR TITLE
docs: add k8s deployment architecture decision report

### DIFF
--- a/docs/prompts/deploy-k8s-testing.md
+++ b/docs/prompts/deploy-k8s-testing.md
@@ -3,8 +3,7 @@
 ## Project Context
 
 I'm working on `k8s-mcp-agent` - an ephemeral GPU diagnostic agent that uses MCP
-(Model Context Protocol) over stdio. The project is at:
-`/Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent`
+(Model Context Protocol) over stdio.
 
 ### Recently Completed
 - PR #61 merged: Multi-stage Dockerfile (`deploy/Containerfile`)

--- a/docs/reports/k8s-deploy-architecture-decision.md
+++ b/docs/reports/k8s-deploy-architecture-decision.md
@@ -294,6 +294,12 @@ spec:
 
 ### Option 3: DaemonSet with Privileged Mode (Fallback)
 
+> ⚠️ **SECURITY WARNING**: This option grants full root-level access to the host.
+> Only use in tightly controlled, admin-only clusters where RuntimeClass is not
+> available. A compromise of the agent or misuse of `kubectl exec` would allow
+> full node takeover. **This is NOT recommended for production or multi-tenant
+> environments.**
+
 For clusters without proper GPU infrastructure:
 
 ```yaml
@@ -322,9 +328,16 @@ spec:
 - No dependency on device plugin/operator
 
 **Cons:**
-- Requires `privileged: true`
+- Requires `privileged: true` — **major security risk**
 - Manual hostPath mounts
 - Driver-version-specific library paths
+
+**Required Mitigations (if used):**
+- Deploy in dedicated namespace with strict RBAC
+- Limit `kubectl exec` access to cluster admins only
+- Use NetworkPolicy to isolate pods
+- Enable audit logging for all exec operations
+- Consider this a temporary measure until RuntimeClass is configured
 
 ### Option 4: On-Demand Pod (Ephemeral Alternative)
 


### PR DESCRIPTION
## Summary

This PR documents the findings from testing k8s-mcp-agent deployment on a real Kubernetes cluster with a Tesla T4 GPU.

## Key Findings

### kubectl debug Does Not Work for GPU Access

Ephemeral containers bypass the nvidia device plugin and cannot access GPUs. This fundamentally breaks the original "Syringe Pattern" as designed.

### Recommended Architecture: DaemonSet + RuntimeClass

| Aspect | Decision |
|--------|----------|
| **Deployment** | DaemonSet on GPU nodes |
| **Entrypoint** | `sleep infinity` (agent runs on exec) |
| **GPU Access** | `runtimeClassName: nvidia` (no GPU allocation) |
| **Scheduler Impact** | None (no resource request) |
| **Security** | Zero trust, least privilege |

### Docker Mode Works

For non-Kubernetes users (Slurm, workstations, NVIDIA Spark):
```bash
docker run --rm -it --gpus all ghcr.io/arangogutierrez/k8s-mcp-agent:latest
```

## Test Results

| Test | Result |
|------|--------|
| Docker with `--gpus all` | ✅ Tesla T4 detected |
| kubectl debug | ❌ NVML fails (no GPU access) |
| K8s Pod with privileged | ✅ Works |
| K8s Pod with RuntimeClass | ✅ Expected to work |

## Files Changed

- `docs/reports/k8s-deploy-architecture-decision.md` - Comprehensive report
- `docs/prompts/deploy-k8s-testing.md` - Testing prompt/guide

## Related Issues

- Creates foundation for #62 (DaemonSet manifests)
- Documents background for #63 (eBPF exploration)
- Documents background for #64 (kubectl plugin)

## Checklist

- [x] Documentation follows project conventions
- [x] No code changes (docs only)
- [x] Commit is signed
