### PR TITLE
chore: rename project to k8s-gpu-mcp-server

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug or unexpected behavior in k8s-mcp-agent
+description: Report a bug or unexpected behavior in k8s-gpu-mcp-server
 title: "[Bug]: "
 labels: ["kind/bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,12 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Discussions
-    url: https://github.com/ArangoGutierrez/k8s-mcp-agent/discussions
+    url: https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/discussions
     about: Ask questions, share ideas, or discuss the project with the community
   - name: 📚 Documentation
-    url: https://github.com/ArangoGutierrez/k8s-mcp-agent/blob/main/README.md
+    url: https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/blob/main/README.md
     about: Read the documentation and getting started guide
   - name: 🔒 Security Advisory (Private)
-    url: https://github.com/ArangoGutierrez/k8s-mcp-agent/security/advisories/new
+    url: https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/security/advisories/new
     about: Report critical security vulnerabilities privately
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest a new feature or enhancement for k8s-mcp-agent
+description: Suggest a new feature or enhancement for k8s-gpu-mcp-server
 title: "[Feature]: "
 labels: ["kind/feature"]
 body:

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -12,7 +12,7 @@ body:
         reporting privately via GitHub Security Advisories instead of creating 
         a public issue:
         
-        https://github.com/ArangoGutierrez/k8s-mcp-agent/security/advisories/new
+        https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/security/advisories/new
         
         Use this template only for lower-severity security concerns or design 
         issues that don't pose immediate exploit risk.

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,6 @@
 # GitHub Configuration
 
-This directory contains GitHub-specific configuration files for the k8s-mcp-agent project.
+This directory contains GitHub-specific configuration files for the k8s-gpu-mcp-server project.
 
 ## 📁 Structure
 
@@ -119,7 +119,7 @@ Triggered on version tags (`v*`):
 
 ### Creating an Issue
 
-1. Go to [Issues](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues/new/choose)
+1. Go to [Issues](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues/new/choose)
 2. Select the appropriate template
 3. Fill out all required fields
 4. Link to relevant milestone (M1-M4)
@@ -144,7 +144,7 @@ When Dependabot opens a dependency update PR:
 
 ## 🔒 Security
 
-- **Private vulnerability reporting**: Use [Security Advisories](https://github.com/ArangoGutierrez/k8s-mcp-agent/security/advisories/new)
+- **Private vulnerability reporting**: Use [Security Advisories](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/security/advisories/new)
 - **Public security issues**: Use `security.yml` template for lower-severity concerns
 - **Trivy scanning**: Automated on every PR and push
 - **Dependabot alerts**: Enabled for security vulnerabilities

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,11 +1,11 @@
-# GitHub Copilot Instructions for k8s-mcp-agent
+# GitHub Copilot Instructions for k8s-gpu-mcp-server
 
 This file provides context and guidelines for GitHub Copilot when generating code, 
-reviews, and suggestions for the k8s-mcp-agent project.
+reviews, and suggestions for the k8s-gpu-mcp-server project.
 
 ## Project Context
 
-**k8s-mcp-agent** is an ephemeral diagnostic agent that provides surgical, real-time 
+**k8s-gpu-mcp-server** is an ephemeral diagnostic agent that provides surgical, real-time 
 NVIDIA GPU hardware introspection for Kubernetes clusters via the Model Context 
 Protocol (MCP). It is designed for AI-assisted troubleshooting by SREs debugging 
 complex hardware failures.

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,4 +1,4 @@
-# Copyright 2026 k8s-mcp-agent contributors
+# Copyright 2026 k8s-gpu-mcp-server contributors
 # SPDX-License-Identifier: Apache-2.0
 
 name: Container Image

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # Development Guide
 
 This guide provides detailed information for developers working on
-`k8s-mcp-agent`.
+`k8s-gpu-mcp-server`.
 
 > 📖 **Also see:** [Architecture Documentation](docs/architecture.md) for
 > system design details and [MCP Usage Guide](docs/mcp-usage.md) for protocol
@@ -18,7 +18,7 @@ This guide provides detailed information for developers working on
 ## Project Structure
 
 ```
-k8s-mcp-agent/
+k8s-gpu-mcp-server/
 ├── cmd/
 │   └── agent/              # Main application entry point
 │       └── main.go         # CLI setup, server initialization
@@ -49,8 +49,8 @@ k8s-mcp-agent/
 
 ```bash
 # Clone repository
-git clone https://github.com/ArangoGutierrez/k8s-mcp-agent.git
-cd k8s-mcp-agent
+git clone https://github.com/ArangoGutierrez/k8s-gpu-mcp-server.git
+cd k8s-gpu-mcp-server
 
 # Download dependencies
 go mod download
@@ -402,12 +402,12 @@ golangci-lint run --verbose
 - [MCP Protocol Specification](https://modelcontextprotocol.io/)
 - [NVML Documentation](https://docs.nvidia.com/deploy/nvml-api/)
 - [Effective Go](https://go.dev/doc/effective_go)
-- [Project Issues](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues)
-- [Milestones](https://github.com/ArangoGutierrez/k8s-mcp-agent/milestones)
+- [Project Issues](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues)
+- [Milestones](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/milestones)
 
 ## Getting Help
 
-- Open an [issue](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues/new)
-- Check [existing issues](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues)
+- Open an [issue](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues/new)
+- Check [existing issues](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues)
 - Review [init.md](init.md) for workflow standards
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2026 k8s-mcp-agent contributors
+# Copyright 2026 k8s-gpu-mcp-server contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # Core utilities
@@ -9,12 +9,12 @@ BIN_DIR  ?= $(CURDIR)/bin
 
 include $(CURDIR)/versions.mk
 
-MODULE := github.com/ArangoGutierrez/k8s-mcp-agent
+MODULE := github.com/ArangoGutierrez/k8s-gpu-mcp-server
 
 # Registry configuration
 ifeq ($(IMAGE_NAME),)
 REGISTRY ?= ghcr.io/arangogutierrez
-IMAGE_NAME = $(REGISTRY)/k8s-mcp-agent
+IMAGE_NAME = $(REGISTRY)/k8s-gpu-mcp-server
 endif
 
 BUILDIMAGE_TAG ?= golang$(GOLANG_VERSION)

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# k8s-mcp-agent
+# k8s-gpu-mcp-server
 
 **Just-in-Time SRE Diagnostic Agent for NVIDIA GPU Clusters on Kubernetes**
 
 [![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![CI Status](https://github.com/ArangoGutierrez/k8s-mcp-agent/workflows/CI/badge.svg)](https://github.com/ArangoGutierrez/k8s-mcp-agent/actions)
-[![GitHub Issues](https://img.shields.io/github/issues/ArangoGutierrez/k8s-mcp-agent)](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues)
-[![GitHub Stars](https://img.shields.io/github/stars/ArangoGutierrez/k8s-mcp-agent?style=social)](https://github.com/ArangoGutierrez/k8s-mcp-agent)
+[![CI Status](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/workflows/CI/badge.svg)](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/actions)
+[![GitHub Issues](https://img.shields.io/github/issues/ArangoGutierrez/k8s-gpu-mcp-server)](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues)
+[![GitHub Stars](https://img.shields.io/github/stars/ArangoGutierrez/k8s-gpu-mcp-server?style=social)](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server)
 [![MCP](https://img.shields.io/badge/MCP-2025--06--18-purple)](https://modelcontextprotocol.io/)
 
 ---
 
 ## Overview
 
-`k8s-mcp-agent` is an **ephemeral diagnostic agent** that provides surgical, 
+`k8s-gpu-mcp-server` is an **ephemeral diagnostic agent** that provides surgical, 
 real-time NVIDIA GPU hardware introspection for Kubernetes clusters via the 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). 
 
@@ -38,8 +38,8 @@ Kubernetes APIs cannot detect.
 
 ```bash
 # Clone and build
-git clone https://github.com/ArangoGutierrez/k8s-mcp-agent.git
-cd k8s-mcp-agent
+git clone https://github.com/ArangoGutierrez/k8s-gpu-mcp-server.git
+cd k8s-gpu-mcp-server
 make agent
 
 # Test with mock GPUs (no hardware required)
@@ -53,13 +53,13 @@ cat examples/gpu_inventory.json | ./bin/agent --nvml-mode=real
 
 ```bash
 # Deploy with Helm (RuntimeClass mode - recommended)
-helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
+helm install k8s-gpu-mcp-server ./deployment/helm/k8s-gpu-mcp-server \
   --namespace gpu-diagnostics --create-namespace
 
 # Find agent pod on target node
 NODE_NAME=<node-name>
 POD=$(kubectl get pods -n gpu-diagnostics \
-  -l app.kubernetes.io/name=k8s-mcp-agent \
+  -l app.kubernetes.io/name=k8s-gpu-mcp-server \
   --field-selector spec.nodeName=$NODE_NAME \
   -o jsonpath='{.items[0].metadata.name}')
 
@@ -139,12 +139,12 @@ Then ask Claude: *"What's the temperature of the GPUs on node gpu-node-5?"*
 
 ## 📈 Project Status
 
-### Current Milestone: [M2: Hardware Introspection](https://github.com/ArangoGutierrez/k8s-mcp-agent/milestone/2)
+### Current Milestone: [M2: Hardware Introspection](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/milestone/2)
 **Due:** January 17, 2026  
 **Progress:** Phase 1 Complete (Real NVML ✅)
 
 ### Completed Milestones
-- ✅ [M1: Foundation & API](https://github.com/ArangoGutierrez/k8s-mcp-agent/milestone/1) - Completed Jan 3, 2026
+- ✅ [M1: Foundation & API](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/milestone/1) - Completed Jan 3, 2026
   - Go module scaffolding
   - MCP stdio server
   - Mock NVML implementation
@@ -156,7 +156,7 @@ Then ask Claude: *"What's the temperature of the GPUs on node gpu-node-5?"*
 - **Jan 3, 2026**: Real NVML integration complete, tested on Tesla T4
 - **Jan 3, 2026**: 74/74 tests passing, 5/5 integration tests on real GPU
 
-📊 **[View All Milestones →](https://github.com/ArangoGutierrez/k8s-mcp-agent/milestones)**
+📊 **[View All Milestones →](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/milestones)**
 
 ---
 
@@ -219,22 +219,22 @@ make dist
 ### From Source
 
 ```bash
-git clone https://github.com/ArangoGutierrez/k8s-mcp-agent.git
-cd k8s-mcp-agent
+git clone https://github.com/ArangoGutierrez/k8s-gpu-mcp-server.git
+cd k8s-gpu-mcp-server
 make agent
-sudo mv bin/agent /usr/local/bin/k8s-mcp-agent
+sudo mv bin/agent /usr/local/bin/k8s-gpu-mcp-server
 ```
 
 ### Using Go
 
 ```bash
-go install github.com/ArangoGutierrez/k8s-mcp-agent/cmd/agent@latest
+go install github.com/ArangoGutierrez/k8s-gpu-mcp-server/cmd/agent@latest
 ```
 
 ### Container Image (Coming in M3)
 
 ```bash
-docker pull ghcr.io/arangogutierrez/k8s-mcp-agent:latest
+docker pull ghcr.io/arangogutierrez/k8s-gpu-mcp-server:latest
 ```
 
 ---
@@ -246,7 +246,7 @@ for details.
 
 ### Quick Contribution Guide
 
-1. Check [open issues](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues)
+1. Check [open issues](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues)
 2. Fork and create feature branch: `git checkout -b feat/my-feature`
 3. Make changes, add tests
 4. Run checks: `make all`
@@ -283,7 +283,7 @@ for details.
 
 ```
 SRE: "Why is the training job on node-5 stuck?"
-Claude → k8s-mcp-agent → Detects XID 48 (ECC Error)
+Claude → k8s-gpu-mcp-server → Detects XID 48 (ECC Error)
 Claude: "Node-5 has uncorrectable memory errors. Drain immediately."
 ```
 
@@ -291,7 +291,7 @@ Claude: "Node-5 has uncorrectable memory errors. Drain immediately."
 
 ```
 SRE: "Are any GPUs thermal throttling?"
-Claude → k8s-mcp-agent → Checks temps and throttle status
+Claude → k8s-gpu-mcp-server → Checks temps and throttle status
 Claude: "GPU 3 is at 86°C and thermal throttling. Check cooling."
 ```
 
@@ -299,7 +299,7 @@ Claude: "GPU 3 is at 86°C and thermal throttling. Check cooling."
 
 ```
 SRE: "Is NVLink properly configured for multi-GPU training?"
-Claude → k8s-mcp-agent → Inspects NVLink topology
+Claude → k8s-gpu-mcp-server → Inspects NVLink topology
 Claude: "All 8 GPUs connected via NVLink, 600GB/s bandwidth."
 ```
 
@@ -307,7 +307,7 @@ Claude: "All 8 GPUs connected via NVLink, 600GB/s bandwidth."
 
 ```
 SRE: "GPU memory is full but no pods are running"
-Claude → k8s-mcp-agent → Lists GPU processes
+Claude → k8s-gpu-mcp-server → Lists GPU processes
 Claude: "Found zombie process PID 12345 using 8GB. Kill it?"
 ```
 
@@ -344,8 +344,8 @@ Apache License 2.0 - See [LICENSE](LICENSE) for details.
 ## 📞 Contact
 
 **Maintainer:** [@ArangoGutierrez](https://github.com/ArangoGutierrez)  
-**Issues:** [GitHub Issues](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues)  
-**Discussions:** [GitHub Discussions](https://github.com/ArangoGutierrez/k8s-mcp-agent/discussions)
+**Issues:** [GitHub Issues](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues)  
+**Discussions:** [GitHub Discussions](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/discussions)
 
 ---
 
@@ -353,8 +353,8 @@ Apache License 2.0 - See [LICENSE](LICENSE) for details.
 
 **⭐ Star us on GitHub — it helps!**
 
-[Report Bug](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues/new?template=bug_report.yml) · 
-[Request Feature](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues/new?template=feature_request.yml) · 
-[View Roadmap](https://github.com/ArangoGutierrez/k8s-mcp-agent/milestones)
+[Report Bug](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues/new?template=bug_report.yml) · 
+[Request Feature](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues/new?template=feature_request.yml) · 
+[View Roadmap](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/milestones)
 
 </div>

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,7 +1,7 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package main is the entry point for the k8s-mcp-agent MCP server.
+// Package main is the entry point for the k8s-gpu-mcp-server MCP server.
 package main
 
 import (
@@ -13,9 +13,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/ArangoGutierrez/k8s-mcp-agent/internal/info"
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/mcp"
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/internal/info"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/mcp"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
 )
 
 const (
@@ -38,7 +38,7 @@ func main() {
 	// Show version and exit if requested
 	if *showVer {
 		buildInfo := info.GetInfo()
-		fmt.Fprintf(os.Stderr, "k8s-mcp-agent version %s (commit %s)\n",
+		fmt.Fprintf(os.Stderr, "k8s-gpu-mcp-server version %s (commit %s)\n",
 			buildInfo.Version, buildInfo.GitCommit)
 		os.Exit(0)
 	}
@@ -54,7 +54,7 @@ func main() {
 	}
 
 	// Log startup information to stderr (structured JSON)
-	log.Printf(`{"level":"info","msg":"starting k8s-mcp-agent","version":"%s","commit":"%s","mode":"%s","nvml_mode":"%s","log_level":"%s"}`,
+	log.Printf(`{"level":"info","msg":"starting k8s-gpu-mcp-server","version":"%s","commit":"%s","mode":"%s","nvml_mode":"%s","log_level":"%s"}`,
 		info.Version(), info.GitCommit(), *mode, *nvmlMode, *logLevel)
 
 	// Setup context with cancellation for graceful shutdown

--- a/deployment/Containerfile
+++ b/deployment/Containerfile
@@ -1,7 +1,7 @@
-# Copyright 2026 k8s-mcp-agent contributors
+# Copyright 2026 k8s-gpu-mcp-server contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# Multi-stage Dockerfile for k8s-mcp-agent
+# Multi-stage Dockerfile for k8s-gpu-mcp-server
 # Produces a minimal, secure container for ephemeral GPU diagnostics
 
 # =============================================================================
@@ -32,8 +32,8 @@ ARG GIT_COMMIT=unknown
 # Using dynamic linking - libnvidia-ml.so provided at runtime by nvidia-container-toolkit
 RUN CGO_ENABLED=1 GOOS=linux go build \
     -ldflags="-s -w \
-        -X github.com/ArangoGutierrez/k8s-mcp-agent/internal/info.version=${VERSION} \
-        -X github.com/ArangoGutierrez/k8s-mcp-agent/internal/info.gitCommit=${GIT_COMMIT}" \
+        -X github.com/ArangoGutierrez/k8s-gpu-mcp-server/internal/info.version=${VERSION} \
+        -X github.com/ArangoGutierrez/k8s-gpu-mcp-server/internal/info.gitCommit=${GIT_COMMIT}" \
     -o /agent \
     ./cmd/agent
 
@@ -48,9 +48,9 @@ FROM busybox:1.37-musl AS busybox
 FROM gcr.io/distroless/base-debian12:nonroot
 
 # OCI Image Labels
-LABEL org.opencontainers.image.title="k8s-mcp-agent"
+LABEL org.opencontainers.image.title="k8s-gpu-mcp-server"
 LABEL org.opencontainers.image.description="Ephemeral GPU diagnostic agent for Kubernetes via MCP"
-LABEL org.opencontainers.image.source="https://github.com/ArangoGutierrez/k8s-mcp-agent"
+LABEL org.opencontainers.image.source="https://github.com/ArangoGutierrez/k8s-gpu-mcp-server"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.vendor="ArangoGutierrez"
 

--- a/deployment/Containerfile.build
+++ b/deployment/Containerfile.build
@@ -1,7 +1,7 @@
-# Copyright 2026 k8s-mcp-agent contributors
+# Copyright 2026 k8s-gpu-mcp-server contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# Development build image for k8s-mcp-agent
+# Development build image for k8s-gpu-mcp-server
 # Used for containerized builds via: make docker-<target>
 
 ARG GOLANG_VERSION=1.25

--- a/deployment/helm/k8s-gpu-mcp-server/Chart.yaml
+++ b/deployment/helm/k8s-gpu-mcp-server/Chart.yaml
@@ -1,8 +1,8 @@
-# Copyright 2026 k8s-mcp-agent contributors
+# Copyright 2026 k8s-gpu-mcp-server contributors
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v2
-name: k8s-mcp-agent
+name: k8s-gpu-mcp-server
 description: |
   Ephemeral GPU diagnostic agent for Kubernetes via MCP.
   Provides on-demand NVIDIA GPU introspection without consuming scheduler resources.
@@ -19,9 +19,9 @@ keywords:
   - nvml
   - kubernetes
 
-home: https://github.com/ArangoGutierrez/k8s-mcp-agent
+home: https://github.com/ArangoGutierrez/k8s-gpu-mcp-server
 sources:
-  - https://github.com/ArangoGutierrez/k8s-mcp-agent
+  - https://github.com/ArangoGutierrez/k8s-gpu-mcp-server
 
 maintainers:
   - name: ArangoGutierrez

--- a/deployment/helm/k8s-gpu-mcp-server/README.md
+++ b/deployment/helm/k8s-gpu-mcp-server/README.md
@@ -1,6 +1,6 @@
-# k8s-mcp-agent Helm Chart
+# k8s-gpu-mcp-server Helm Chart
 
-Deploys the k8s-mcp-agent as a DaemonSet for on-demand GPU diagnostics.
+Deploys the k8s-gpu-mcp-server as a DaemonSet for on-demand GPU diagnostics.
 
 ## Prerequisites
 
@@ -15,7 +15,7 @@ Deploys the k8s-mcp-agent as a DaemonSet for on-demand GPU diagnostics.
 ### Quick Start (RuntimeClass mode)
 
 ```bash
-helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
+helm install k8s-gpu-mcp-server ./deployment/helm/k8s-gpu-mcp-server \
   --namespace gpu-diagnostics \
   --create-namespace
 ```
@@ -25,7 +25,7 @@ helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
 For clusters without RuntimeClass configured:
 
 ```bash
-helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
+helm install k8s-gpu-mcp-server ./deployment/helm/k8s-gpu-mcp-server \
   --namespace gpu-diagnostics \
   --create-namespace \
   --set gpu.runtimeClass.enabled=false \
@@ -66,7 +66,7 @@ Requests `nvidia.com/gpu` resources from the NVIDIA Device Plugin. Use this
 if RuntimeClass is not available (e.g., cri-dockerd clusters).
 
 ```bash
-helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
+helm install k8s-gpu-mcp-server ./deployment/helm/k8s-gpu-mcp-server \
   --set gpu.runtimeClass.enabled=false \
   --set gpu.resourceRequest.enabled=true
 ```
@@ -82,13 +82,13 @@ Requires K8s 1.26+ with DynamicResourceAllocation feature gate (beta in 1.31+).
 
 ```bash
 # Using an existing ResourceClaimTemplate
-helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
+helm install k8s-gpu-mcp-server ./deployment/helm/k8s-gpu-mcp-server \
   --set gpu.runtimeClass.enabled=false \
   --set gpu.resourceClaim.enabled=true \
   --set gpu.resourceClaim.templateName=gpu-template
 
 # Using inline ResourceClaim spec
-helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
+helm install k8s-gpu-mcp-server ./deployment/helm/k8s-gpu-mcp-server \
   --set gpu.runtimeClass.enabled=false \
   --set gpu.resourceClaim.enabled=true \
   --set-json 'gpu.resourceClaim.spec={"devices":{"requests":[{"name":"gpu","deviceClassName":"gpu.nvidia.com"}]}}'
@@ -129,7 +129,7 @@ See [values.yaml](values.yaml) for all configuration options.
 ```bash
 NODE_NAME=<your-gpu-node>
 POD=$(kubectl get pods -n gpu-diagnostics \
-  -l app.kubernetes.io/name=k8s-mcp-agent \
+  -l app.kubernetes.io/name=k8s-gpu-mcp-server \
   --field-selector spec.nodeName=$NODE_NAME \
   -o jsonpath='{.items[0].metadata.name}')
 ```
@@ -151,7 +151,7 @@ echo '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-0
 ## Uninstallation
 
 ```bash
-helm uninstall k8s-mcp-agent -n gpu-diagnostics
+helm uninstall k8s-gpu-mcp-server -n gpu-diagnostics
 kubectl delete namespace gpu-diagnostics
 ```
 

--- a/deployment/helm/k8s-gpu-mcp-server/templates/NOTES.txt
+++ b/deployment/helm/k8s-gpu-mcp-server/templates/NOTES.txt
@@ -1,8 +1,8 @@
 ===============================================================================
- k8s-mcp-agent deployed successfully!
+ k8s-gpu-mcp-server deployed successfully!
 ===============================================================================
 
-Namespace: {{ include "k8s-mcp-agent.namespace" . }}
+Namespace: {{ include "k8s-gpu-mcp-server.namespace" . }}
 
 GPU Access Mode:
 {{- if .Values.gpu.runtimeClass.enabled }}
@@ -31,19 +31,19 @@ USAGE
 1. Find the agent pod on a specific node:
 
    NODE_NAME=<your-gpu-node>
-   POD=$(kubectl get pods -n {{ include "k8s-mcp-agent.namespace" . }} \
-     -l app.kubernetes.io/name={{ include "k8s-mcp-agent.name" . }} \
+   POD=$(kubectl get pods -n {{ include "k8s-gpu-mcp-server.namespace" . }} \
+     -l app.kubernetes.io/name={{ include "k8s-gpu-mcp-server.name" . }} \
      --field-selector spec.nodeName=$NODE_NAME \
      -o jsonpath='{.items[0].metadata.name}')
 
 2. Start a diagnostic session:
 
-   kubectl exec -it -n {{ include "k8s-mcp-agent.namespace" . }} $POD -- /agent --mode=read-only
+   kubectl exec -it -n {{ include "k8s-gpu-mcp-server.namespace" . }} $POD -- /agent --mode=read-only
 
 3. Or pipe JSON-RPC commands directly:
 
    echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_gpu_inventory","arguments":{}},"id":1}' | \
-     kubectl exec -i -n {{ include "k8s-mcp-agent.namespace" . }} $POD -- /agent
+     kubectl exec -i -n {{ include "k8s-gpu-mcp-server.namespace" . }} $POD -- /agent
 
 -------------------------------------------------------------------------------
 PREREQUISITES
@@ -84,9 +84,9 @@ Install NVIDIA DRA Driver:
 DOCUMENTATION
 -------------------------------------------------------------------------------
 
-- Architecture: https://github.com/ArangoGutierrez/k8s-mcp-agent/blob/main/docs/architecture.md
-- MCP Usage: https://github.com/ArangoGutierrez/k8s-mcp-agent/blob/main/docs/mcp-usage.md
-- Quick Start: https://github.com/ArangoGutierrez/k8s-mcp-agent/blob/main/docs/quickstart.md
+- Architecture: https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/blob/main/docs/architecture.md
+- MCP Usage: https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/blob/main/docs/mcp-usage.md
+- Quick Start: https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/blob/main/docs/quickstart.md
 
 ===============================================================================
 

--- a/deployment/helm/k8s-gpu-mcp-server/templates/_helpers.tpl
+++ b/deployment/helm/k8s-gpu-mcp-server/templates/_helpers.tpl
@@ -1,19 +1,19 @@
 {{/*
-Copyright 2026 k8s-mcp-agent contributors
+Copyright 2026 k8s-gpu-mcp-server contributors
 SPDX-License-Identifier: Apache-2.0
 */}}
 
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "k8s-mcp-agent.name" -}}
+{{- define "k8s-gpu-mcp-server.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create a default fully qualified app name.
 */}}
-{{- define "k8s-mcp-agent.fullname" -}}
+{{- define "k8s-gpu-mcp-server.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -29,16 +29,16 @@ Create a default fully qualified app name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "k8s-mcp-agent.chart" -}}
+{{- define "k8s-gpu-mcp-server.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "k8s-mcp-agent.labels" -}}
-helm.sh/chart: {{ include "k8s-mcp-agent.chart" . }}
-{{ include "k8s-mcp-agent.selectorLabels" . }}
+{{- define "k8s-gpu-mcp-server.labels" -}}
+helm.sh/chart: {{ include "k8s-gpu-mcp-server.chart" . }}
+{{ include "k8s-gpu-mcp-server.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -48,17 +48,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "k8s-mcp-agent.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "k8s-mcp-agent.name" . }}
+{{- define "k8s-gpu-mcp-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k8s-gpu-mcp-server.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "k8s-mcp-agent.serviceAccountName" -}}
+{{- define "k8s-gpu-mcp-server.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "k8s-mcp-agent.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "k8s-gpu-mcp-server.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -67,7 +67,7 @@ Create the name of the service account to use
 {{/*
 Create the namespace name
 */}}
-{{- define "k8s-mcp-agent.namespace" -}}
+{{- define "k8s-gpu-mcp-server.namespace" -}}
 {{- if .Values.namespace.create }}
 {{- .Values.namespace.name }}
 {{- else }}
@@ -79,7 +79,7 @@ Create the namespace name
 Validate GPU access configuration.
 Ensures only one GPU access method is enabled at a time.
 */}}
-{{- define "k8s-mcp-agent.validateGPUConfig" -}}
+{{- define "k8s-gpu-mcp-server.validateGPUConfig" -}}
 {{- $enabledCount := 0 }}
 {{- $enabledMethods := list }}
 {{- if .Values.gpu.runtimeClass.enabled }}

--- a/deployment/helm/k8s-gpu-mcp-server/templates/daemonset.yaml
+++ b/deployment/helm/k8s-gpu-mcp-server/templates/daemonset.yaml
@@ -1,29 +1,29 @@
 {{/*
-Copyright 2026 k8s-mcp-agent contributors
+Copyright 2026 k8s-gpu-mcp-server contributors
 SPDX-License-Identifier: Apache-2.0
 */}}
 
 {{- /* Validate GPU configuration before rendering */}}
-{{- include "k8s-mcp-agent.validateGPUConfig" . }}
+{{- include "k8s-gpu-mcp-server.validateGPUConfig" . }}
 
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "k8s-mcp-agent.fullname" . }}
-  namespace: {{ include "k8s-mcp-agent.namespace" . }}
+  name: {{ include "k8s-gpu-mcp-server.fullname" . }}
+  namespace: {{ include "k8s-gpu-mcp-server.namespace" . }}
   labels:
-    {{- include "k8s-mcp-agent.labels" . | nindent 4 }}
+    {{- include "k8s-gpu-mcp-server.labels" . | nindent 4 }}
     app.kubernetes.io/component: gpu-diagnostics
 spec:
   selector:
     matchLabels:
-      {{- include "k8s-mcp-agent.selectorLabels" . | nindent 6 }}
+      {{- include "k8s-gpu-mcp-server.selectorLabels" . | nindent 6 }}
   updateStrategy:
     {{- toYaml .Values.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:
-        {{- include "k8s-mcp-agent.selectorLabels" . | nindent 8 }}
+        {{- include "k8s-gpu-mcp-server.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: gpu-diagnostics
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
@@ -48,7 +48,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      serviceAccountName: {{ include "k8s-mcp-agent.serviceAccountName" . }}
+      serviceAccountName: {{ include "k8s-gpu-mcp-server.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -60,7 +60,7 @@ spec:
         {{- if .Values.gpu.resourceClaim.templateName }}
         resourceClaimTemplateName: {{ .Values.gpu.resourceClaim.templateName }}
         {{- else if .Values.gpu.resourceClaim.spec }}
-        resourceClaimName: {{ include "k8s-mcp-agent.fullname" . }}-gpu
+        resourceClaimName: {{ include "k8s-gpu-mcp-server.fullname" . }}-gpu
         {{- end }}
       {{- end }}
       containers:

--- a/deployment/helm/k8s-gpu-mcp-server/templates/namespace.yaml
+++ b/deployment/helm/k8s-gpu-mcp-server/templates/namespace.yaml
@@ -1,5 +1,5 @@
 {{/*
-Copyright 2026 k8s-mcp-agent contributors
+Copyright 2026 k8s-gpu-mcp-server contributors
 SPDX-License-Identifier: Apache-2.0
 */}}
 
@@ -9,7 +9,7 @@ kind: Namespace
 metadata:
   name: {{ .Values.namespace.name }}
   labels:
-    {{- include "k8s-mcp-agent.labels" . | nindent 4 }}
+    {{- include "k8s-gpu-mcp-server.labels" . | nindent 4 }}
     app.kubernetes.io/component: gpu-diagnostics
 {{- end }}
 

--- a/deployment/helm/k8s-gpu-mcp-server/templates/resourceclaim.yaml
+++ b/deployment/helm/k8s-gpu-mcp-server/templates/resourceclaim.yaml
@@ -1,5 +1,5 @@
 {{/*
-Copyright 2026 k8s-mcp-agent contributors
+Copyright 2026 k8s-gpu-mcp-server contributors
 SPDX-License-Identifier: Apache-2.0
 */}}
 
@@ -12,10 +12,10 @@ SPDX-License-Identifier: Apache-2.0
 apiVersion: resource.k8s.io/v1alpha3
 kind: ResourceClaim
 metadata:
-  name: {{ include "k8s-mcp-agent.fullname" . }}-gpu
-  namespace: {{ include "k8s-mcp-agent.namespace" . }}
+  name: {{ include "k8s-gpu-mcp-server.fullname" . }}-gpu
+  namespace: {{ include "k8s-gpu-mcp-server.namespace" . }}
   labels:
-    {{- include "k8s-mcp-agent.labels" . | nindent 4 }}
+    {{- include "k8s-gpu-mcp-server.labels" . | nindent 4 }}
 spec:
   {{- toYaml .Values.gpu.resourceClaim.spec | nindent 2 }}
 {{- end }}

--- a/deployment/helm/k8s-gpu-mcp-server/templates/serviceaccount.yaml
+++ b/deployment/helm/k8s-gpu-mcp-server/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{/*
-Copyright 2026 k8s-mcp-agent contributors
+Copyright 2026 k8s-gpu-mcp-server contributors
 SPDX-License-Identifier: Apache-2.0
 */}}
 
@@ -7,10 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "k8s-mcp-agent.serviceAccountName" . }}
-  namespace: {{ include "k8s-mcp-agent.namespace" . }}
+  name: {{ include "k8s-gpu-mcp-server.serviceAccountName" . }}
+  namespace: {{ include "k8s-gpu-mcp-server.namespace" . }}
   labels:
-    {{- include "k8s-mcp-agent.labels" . | nindent 4 }}
+    {{- include "k8s-gpu-mcp-server.labels" . | nindent 4 }}
     app.kubernetes.io/component: gpu-diagnostics
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/deployment/helm/k8s-gpu-mcp-server/values.yaml
+++ b/deployment/helm/k8s-gpu-mcp-server/values.yaml
@@ -1,7 +1,7 @@
-# Copyright 2026 k8s-mcp-agent contributors
+# Copyright 2026 k8s-gpu-mcp-server contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# Default values for k8s-mcp-agent Helm chart.
+# Default values for k8s-gpu-mcp-server Helm chart.
 
 # -- Override the name of the chart
 nameOverride: ""
@@ -18,7 +18,7 @@ namespace:
 # Image configuration
 image:
   # -- Container image repository
-  repository: ghcr.io/arangogutierrez/k8s-mcp-agent
+  repository: ghcr.io/arangogutierrez/k8s-gpu-mcp-server
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (default is chart appVersion)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Complete documentation for `k8s-mcp-agent` - Just-in-Time SRE Diagnostic
+Complete documentation for `k8s-gpu-mcp-server` - Just-in-Time SRE Diagnostic
 Agent for NVIDIA GPU Clusters on Kubernetes.
 
 ## 📚 Documentation Index
@@ -90,8 +90,8 @@ All code examples are available in the [`examples/`](../examples/) directory:
 
 ## 🤝 Getting Help
 
-- **Issues**: [GitHub Issues](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/ArangoGutierrez/k8s-mcp-agent/discussions)
+- **Issues**: [GitHub Issues](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/discussions)
 - **Maintainer**: [@ArangoGutierrez](https://github.com/ArangoGutierrez)
 
 ## 📄 License

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 This document describes the architecture, design decisions, and technical
-implementation of `k8s-mcp-agent`.
+implementation of `k8s-gpu-mcp-server`.
 
 ## Table of Contents
 
@@ -15,7 +15,7 @@ implementation of `k8s-mcp-agent`.
 
 ## Overview
 
-`k8s-mcp-agent` is an **ephemeral diagnostic agent** that provides real-time
+`k8s-gpu-mcp-server` is an **ephemeral diagnostic agent** that provides real-time
 NVIDIA GPU hardware introspection for Kubernetes clusters via the Model
 Context Protocol (MCP).
 
@@ -35,7 +35,7 @@ Unlike traditional monitoring (always-running exporters with network endpoints),
 the agent only runs during active diagnostic sessions:
 
 ```
-Traditional Monitoring:              k8s-mcp-agent:
+Traditional Monitoring:              k8s-gpu-mcp-server:
 ┌─────────────┐                     ┌─────────────────────────┐
 │ DaemonSet   │                     │ DaemonSet               │
 │ (Always On) │                     │ └─ sleep infinity       │
@@ -100,7 +100,7 @@ type Interface interface {
 
 ### Deployment Modes
 
-k8s-mcp-agent supports multiple deployment modes:
+k8s-gpu-mcp-server supports multiple deployment modes:
 
 | Mode | Use Case | Command |
 |------|----------|---------|
@@ -127,7 +127,7 @@ k8s-mcp-agent supports multiple deployment modes:
 │                    Kubernetes Node (GPU-enabled)              │
 │                                                               │
 │  ┌────────────────────────────────────────────────────────┐  │
-│  │  DaemonSet Pod (k8s-mcp-agent)                         │  │
+│  │  DaemonSet Pod (k8s-gpu-mcp-server)                         │  │
 │  │  - runtimeClassName: nvidia (CDI injection)            │  │
 │  │  - No nvidia.com/gpu request (doesn't block scheduler) │  │
 │  │  ┌──────────────────────────────────────────────────┐  │  │
@@ -175,7 +175,7 @@ by the nvidia-container-toolkit. The agent supports clusters with:
 For detailed deployment information, see
 [Architecture Decision Report](reports/k8s-deploy-architecture-decision.md).
 
-**Helm Chart:** [`deployment/helm/k8s-mcp-agent/`](../deployment/helm/k8s-mcp-agent/)
+**Helm Chart:** [`deployment/helm/k8s-gpu-mcp-server/`](../deployment/helm/k8s-gpu-mcp-server/)
 
 The chart supports three GPU access modes:
 
@@ -188,10 +188,10 @@ The chart supports three GPU access modes:
 Install with:
 ```bash
 # RuntimeClass mode (recommended)
-helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent
+helm install k8s-gpu-mcp-server ./deployment/helm/k8s-gpu-mcp-server
 
 # Fallback mode (no RuntimeClass)
-helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
+helm install k8s-gpu-mcp-server ./deployment/helm/k8s-gpu-mcp-server \
   --set gpu.runtimeClass.enabled=false \
   --set gpu.resourceRequest.enabled=true
 ```
@@ -688,7 +688,7 @@ for detailed analysis.
 ## File Structure
 
 ```
-k8s-mcp-agent/
+k8s-gpu-mcp-server/
 ├── cmd/agent/              # Entry point
 │   └── main.go             # CLI, lifecycle, wiring
 │

--- a/docs/mcp-usage.md
+++ b/docs/mcp-usage.md
@@ -1,6 +1,6 @@
 # MCP Usage Guide
 
-Learn how to interact with `k8s-mcp-agent` using the Model Context Protocol.
+Learn how to interact with `k8s-gpu-mcp-server` using the Model Context Protocol.
 
 ## Table of Contents
 
@@ -18,7 +18,7 @@ Learn how to interact with `k8s-mcp-agent` using the Model Context Protocol.
 The Model Context Protocol (MCP) is an open protocol that enables AI
 assistants to securely interact with external tools and data sources.
 
-`k8s-mcp-agent` implements MCP over **stdio** (standard input/output),
+`k8s-gpu-mcp-server` implements MCP over **stdio** (standard input/output),
 making it compatible with:
 
 - **Claude Desktop** - Anthropic's AI assistant
@@ -101,7 +101,7 @@ Add to your Claude Desktop MCP configuration:
       "args": [
         "debug",
         "node/gpu-node-5",
-        "--image=ghcr.io/arangogutierrez/k8s-mcp-agent:latest",
+        "--image=ghcr.io/arangogutierrez/k8s-gpu-mcp-server:latest",
         "--profile=sysadmin",
         "--",
         "/agent",
@@ -162,7 +162,7 @@ Claude: [Calls get_gpu_inventory tool]
 
 ```typescript
 // Ask Cursor AI:
-// "Query the GPU inventory using k8s-mcp-agent"
+// "Query the GPU inventory using k8s-gpu-mcp-server"
 
 // Cursor will:
 // 1. Initialize MCP session
@@ -193,7 +193,7 @@ echo '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-0
       }
     },
     "serverInfo": {
-      "name": "k8s-mcp-agent",
+      "name": "k8s-gpu-mcp-server",
       "version": "0.1.0-alpha"
     }
   }

--- a/docs/prompts/daemonset-manifests.md
+++ b/docs/prompts/daemonset-manifests.md
@@ -2,7 +2,7 @@
 
 ## Issue Reference
 
-- **Issue:** [#62 - feat: Add DaemonSet deployment manifests for Kubernetes](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues/62)
+- **Issue:** [#62 - feat: Add DaemonSet deployment manifests for Kubernetes](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues/62)
 - **Priority:** P1-High
 - **Labels:** kind/feature, area/k8s-ephemeral, ops/security
 
@@ -15,7 +15,7 @@ device plugin. The recommended deployment pattern is a DaemonSet with
 
 ## Objective
 
-Create production-ready Kubernetes manifests for deploying k8s-mcp-agent to GPU
+Create production-ready Kubernetes manifests for deploying k8s-gpu-mcp-server to GPU
 clusters with NVIDIA Device Plugin, GPU Operator, or DRA driver.
 
 ## Step 0: Create Feature Branch
@@ -28,20 +28,20 @@ git checkout -b feat/daemonset-manifests
 
 ## Files to Create
 
-### 1. `deployment/helm/k8s-mcp-agent/templates/namespace.yaml`
+### 1. `deployment/helm/k8s-gpu-mcp-server/templates/namespace.yaml`
 
 Dedicated namespace for GPU diagnostics:
-- Name: `gpu-diagnostics` (or `k8s-mcp-agent`)
+- Name: `gpu-diagnostics` (or `k8s-gpu-mcp-server`)
 - Labels for identification
 
-### 2. `deployment/helm/k8s-mcp-agent/templates/serviceaccount.yaml`
+### 2. `deployment/helm/k8s-gpu-mcp-server/templates/serviceaccount.yaml`
 
 ServiceAccount and RBAC configuration:
 - ServiceAccount for the DaemonSet
 - Minimal permissions (read-only cluster info if needed)
 - Consider future operator mode permissions
 
-### 3. `deployment/helm/k8s-mcp-agent/templates/daemonset.yaml`
+### 3. `deployment/helm/k8s-gpu-mcp-server/templates/daemonset.yaml`
 
 Primary DaemonSet manifest with RuntimeClass:
 
@@ -49,16 +49,16 @@ Primary DaemonSet manifest with RuntimeClass:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: k8s-mcp-agent
+  name: k8s-gpu-mcp-server
   namespace: gpu-diagnostics
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: k8s-mcp-agent
+      app.kubernetes.io/name: k8s-gpu-mcp-server
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: k8s-mcp-agent
+        app.kubernetes.io/name: k8s-gpu-mcp-server
         app.kubernetes.io/component: gpu-diagnostics
     spec:
       runtimeClassName: nvidia  # CDI injection for GPU access
@@ -68,10 +68,10 @@ spec:
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
-      serviceAccountName: k8s-mcp-agent
+      serviceAccountName: k8s-gpu-mcp-server
       containers:
       - name: agent
-        image: ghcr.io/arangogutierrez/k8s-mcp-agent:latest
+        image: ghcr.io/arangogutierrez/k8s-gpu-mcp-server:latest
         command: ["sleep", "infinity"]
         stdin: true
         tty: true
@@ -91,7 +91,7 @@ spec:
         # NO nvidia.com/gpu resource - monitors all GPUs without allocation
 ```
 
-### 4. `deployment/helm/k8s-mcp-agent/values.yaml`
+### 4. `deployment/helm/k8s-gpu-mcp-server/values.yaml`
 
 Kustomize base for easy customization:
 ```yaml
@@ -152,7 +152,7 @@ Once deployed, users diagnose GPUs with:
 ```bash
 # Find pod on target node
 POD=$(kubectl get pods -n gpu-diagnostics \
-  -l app.kubernetes.io/name=k8s-mcp-agent \
+  -l app.kubernetes.io/name=k8s-gpu-mcp-server \
   --field-selector spec.nodeName=<node-name> \
   -o jsonpath='{.items[0].metadata.name}')
 

--- a/docs/prompts/deploy-k8s-testing.md
+++ b/docs/prompts/deploy-k8s-testing.md
@@ -1,8 +1,8 @@
-# Deploy k8s-mcp-agent to Kubernetes Cluster
+# Deploy k8s-gpu-mcp-server to Kubernetes Cluster
 
 ## Project Context
 
-I'm working on `k8s-mcp-agent` - an ephemeral GPU diagnostic agent that uses MCP
+I'm working on `k8s-gpu-mcp-server` - an ephemeral GPU diagnostic agent that uses MCP
 (Model Context Protocol) over stdio.
 
 ### Recently Completed
@@ -17,7 +17,7 @@ I'm working on `k8s-mcp-agent` - an ephemeral GPU diagnostic agent that uses MCP
 
 ## Objective
 
-Test the k8s-mcp-agent deployment pipeline on a real Kubernetes cluster:
+Test the k8s-gpu-mcp-server deployment pipeline on a real Kubernetes cluster:
 
 1. Push container image to ghcr.io
 2. Deploy via `kubectl debug` (ephemeral injection pattern)
@@ -49,18 +49,18 @@ Option B: Push manually using docker + ghcr.io login
 echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
 
 # Build and push
-docker build -f deployment/Containerfile -t ghcr.io/arangogutierrez/k8s-mcp-agent:latest .
-docker push ghcr.io/arangogutierrez/k8s-mcp-agent:latest
+docker build -f deployment/Containerfile -t ghcr.io/arangogutierrez/k8s-gpu-mcp-server:latest .
+docker push ghcr.io/arangogutierrez/k8s-gpu-mcp-server:latest
 ```
 
 ### Step 2: Verify Image is Pullable
 
 ```bash
 # Verify image exists
-docker pull ghcr.io/arangogutierrez/k8s-mcp-agent:latest
+docker pull ghcr.io/arangogutierrez/k8s-gpu-mcp-server:latest
 
 # Check image size
-docker images ghcr.io/arangogutierrez/k8s-mcp-agent:latest
+docker images ghcr.io/arangogutierrez/k8s-gpu-mcp-server:latest
 ```
 
 ### Step 3: Test kubectl debug Injection
@@ -68,7 +68,7 @@ docker images ghcr.io/arangogutierrez/k8s-mcp-agent:latest
 ```bash
 # Inject agent into node (mock GPU mode since no real GPUs)
 kubectl debug node/ip-10-0-0-194 \
-  --image=ghcr.io/arangogutierrez/k8s-mcp-agent:latest \
+  --image=ghcr.io/arangogutierrez/k8s-gpu-mcp-server:latest \
   -it --tty \
   -- /agent --nvml-mode=mock --mode=read-only
 ```

--- a/docs/prompts/gpu-health-monitoring.md
+++ b/docs/prompts/gpu-health-monitoring.md
@@ -2,9 +2,9 @@
 
 ## PROJECT CONTEXT
 
-**Repository:** https://github.com/ArangoGutierrez/k8s-mcp-agent  
+**Repository:** https://github.com/ArangoGutierrez/k8s-gpu-mcp-server  
 **Current Branch:** `main`  
-**Workspace:** `/Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent`
+**Workspace:** `/Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server`
 
 ### Current State (Jan 3, 2026)
 - ✅ M1 Complete: MCP stdio server working, Mock NVML implemented
@@ -24,7 +24,7 @@
 - **SSH:** `ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com`
 - **GPU:** Tesla T4 (16GB), Driver 575.57.08, CUDA 12.9
 - **Go:** 1.25.5 at `/usr/local/go/bin/go`
-- **Code Location:** `~/k8s-mcp-agent`
+- **Code Location:** `~/k8s-gpu-mcp-server`
 - **Kubernetes:** v1.33.3 single node
 
 ---
@@ -61,7 +61,7 @@ package tools
 
 import (
 	"context"
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -502,7 +502,7 @@ Create `examples/gpu_health.json`:
 ### Local Testing (Mock NVML)
 
 ```bash
-cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
 
 # Run unit tests
 make test
@@ -521,7 +521,7 @@ cat examples/gpu_health.json | ./bin/agent --nvml-mode=mock
 ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com
 
 # Navigate to code
-cd ~/k8s-mcp-agent
+cd ~/k8s-gpu-mcp-server
 
 # Pull latest changes
 git fetch origin
@@ -651,7 +651,7 @@ go test -tags=integration -v ./pkg/tools/
 
 ### Step 1: Create Branch and Structure
 ```bash
-cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
 git checkout main && git pull
 git checkout -b feat/m2-gpu-health
 
@@ -841,7 +841,7 @@ gh pr create          # Create PR
 ### Remote Machine
 ```bash
 ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com
-cd ~/k8s-mcp-agent
+cd ~/k8s-gpu-mcp-server
 export PATH=/usr/local/go/bin:$PATH
 ```
 

--- a/docs/prompts/gpu-inventory-enhancement.md
+++ b/docs/prompts/gpu-inventory-enhancement.md
@@ -2,10 +2,10 @@
 
 ## PROJECT CONTEXT
 
-**Repository:** https://github.com/ArangoGutierrez/k8s-mcp-agent  
+**Repository:** https://github.com/ArangoGutierrez/k8s-gpu-mcp-server  
 **Issue:** Enhancement of `get_gpu_inventory` tool  
 **Milestone:** M2: Hardware Introspection (Due: Jan 17, 2026)  
-**Workspace:** `/Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent`
+**Workspace:** `/Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server`
 
 ### Current State (Jan 4, 2026)
 - ✅ M1 Complete: MCP stdio server working
@@ -24,14 +24,14 @@
 - **SSH:** `ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com`
 - **GPU:** Tesla T4 (16GB), Driver 575.57.08, CUDA 12.9
 - **Go:** 1.25.5 at `/usr/local/go/bin/go`
-- **Code Location:** `~/k8s-mcp-agent`
+- **Code Location:** `~/k8s-gpu-mcp-server`
 
 ---
 
 ## FIRST TASK: Create Branch
 
 ```bash
-cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
 git checkout main && git pull
 git checkout -b feat/m2-inventory-enhancement
 ```
@@ -371,7 +371,7 @@ func TestGPUInventoryHandler_NestedStructures(t *testing.T) {
 ### Local Testing (Mock NVML)
 
 ```bash
-cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
 
 # Run unit tests
 make test
@@ -388,7 +388,7 @@ make agent
 ```bash
 ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com
 
-cd ~/k8s-mcp-agent
+cd ~/k8s-gpu-mcp-server
 git fetch origin
 git checkout feat/m2-inventory-enhancement
 
@@ -486,7 +486,7 @@ gh pr create          # Create PR
 ### Remote Machine
 ```bash
 ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com
-cd ~/k8s-mcp-agent
+cd ~/k8s-gpu-mcp-server
 export PATH=/usr/local/go/bin:$PATH
 ```
 

--- a/docs/prompts/m2-xid-implementation.md
+++ b/docs/prompts/m2-xid-implementation.md
@@ -1,7 +1,7 @@
 # M2 Phase 2: XID Error Analysis - Implementation Prompt
 
-**Project:** `k8s-mcp-agent` - Just-in-Time SRE Diagnostic Agent for NVIDIA GPU Clusters  
-**Repository:** https://github.com/ArangoGutierrez/k8s-mcp-agent  
+**Project:** `k8s-gpu-mcp-server` - Just-in-Time SRE Diagnostic Agent for NVIDIA GPU Clusters  
+**Repository:** https://github.com/ArangoGutierrez/k8s-gpu-mcp-server  
 **Branch:** Create new: `feat/m2-xid-error-analysis`  
 **Milestone:** M2: Hardware Introspection (Due: Jan 17, 2026)
 
@@ -42,7 +42,7 @@ pkg/tools/                  # MCP tool handlers
 - **GPU:** Tesla T4 (15GB) with NVIDIA Driver 575.57.08
 - **Go:** 1.25.5 installed at `/usr/local/go/bin/go`
 - **Kubernetes:** v1.33.3 single node
-- **Code:** `~/k8s-mcp-agent` (clone available)
+- **Code:** `~/k8s-gpu-mcp-server` (clone available)
 
 ---
 
@@ -339,7 +339,7 @@ Follow the pattern from `gpu_inventory.go`:
 **pkg/mcp/server.go:**
 ```go
 // Add import
-import "github.com/ArangoGutierrez/k8s-mcp-agent/pkg/xid"
+import "github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/xid"
 
 // In New() function, register tool:
 xidHandler := tools.NewAnalyzeXIDHandler(cfg.NVMLClient)
@@ -365,7 +365,7 @@ mcpServer.AddTool(tools.GetAnalyzeXIDTool(), xidHandler.Handle)
 
 ```bash
 # On remote machine
-cd ~/k8s-mcp-agent
+cd ~/k8s-gpu-mcp-server
 git pull
 git checkout feat/m2-xid-error-analysis
 export PATH=/usr/local/go/bin:$PATH
@@ -658,7 +658,7 @@ func (h *AnalyzeXIDHandler) Handle(ctx context.Context, request mcp.CallToolRequ
 
 ```bash
 # On your local machine
-cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
 git checkout main
 git pull
 git checkout -b feat/m2-xid-error-analysis

--- a/docs/prompts/m2-xid-task.md
+++ b/docs/prompts/m2-xid-task.md
@@ -1,4 +1,4 @@
-# Task: Implement XID Error Analysis for k8s-mcp-agent
+# Task: Implement XID Error Analysis for k8s-gpu-mcp-server
 
 **Copy this entire message to start a new chat window** ↓
 
@@ -6,11 +6,11 @@
 
 ## CONTEXT
 
-I'm working on `k8s-mcp-agent` - an MCP server that provides NVIDIA GPU diagnostics for Kubernetes.
+I'm working on `k8s-gpu-mcp-server` - an MCP server that provides NVIDIA GPU diagnostics for Kubernetes.
 
-**Repository:** https://github.com/ArangoGutierrez/k8s-mcp-agent  
+**Repository:** https://github.com/ArangoGutierrez/k8s-gpu-mcp-server  
 **Current Branch:** `main`  
-**Workspace:** `/Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent`
+**Workspace:** `/Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server`
 
 **Current State:**
 - ✅ M1 Complete: MCP stdio server, Mock NVML
@@ -32,7 +32,7 @@ I'm working on `k8s-mcp-agent` - an MCP server that provides NVIDIA GPU diagnost
 - Remote machine: `ssh -i ~/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com`
 - Tesla T4 (15GB), NVIDIA Driver 575.57.08
 - Go 1.25.5 at `/usr/local/go/bin/go`
-- Code at `~/k8s-mcp-agent`
+- Code at `~/k8s-gpu-mcp-server`
 
 ---
 
@@ -164,7 +164,7 @@ mcpServer.AddTool(tools.GetAnalyzeXIDTool(), xidHandler.Handle)
 
 ```bash
 # Start
-cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
 git checkout main && git pull
 git checkout -b feat/m2-xid-error-analysis
 
@@ -180,7 +180,7 @@ go test -tags=integration ./pkg/xid/
 
 # Test on Tesla T4
 ssh -i ~/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com
-cd ~/k8s-mcp-agent && git pull && git checkout feat/m2-xid-error-analysis
+cd ~/k8s-gpu-mcp-server && git pull && git checkout feat/m2-xid-error-analysis
 export PATH=/usr/local/go/bin:$PATH
 go build -o bin/agent ./cmd/agent
 sudo dmesg | grep -i xid  # Check for existing XIDs

--- a/docs/prompts/nvml-interface-extension.md
+++ b/docs/prompts/nvml-interface-extension.md
@@ -2,10 +2,10 @@
 
 ## PROJECT CONTEXT
 
-**Repository:** https://github.com/ArangoGutierrez/k8s-mcp-agent  
+**Repository:** https://github.com/ArangoGutierrez/k8s-gpu-mcp-server  
 **Issue:** #5 - [NVML] Implement Wrapper Interface  
 **Milestone:** M2: Hardware Introspection (Due: Jan 17, 2026)  
-**Workspace:** `/Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent`
+**Workspace:** `/Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server`
 
 ### Current State (Jan 4, 2026)
 - ✅ M1 Complete: MCP stdio server working
@@ -23,14 +23,14 @@
 - **SSH:** `ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com`
 - **GPU:** Tesla T4 (16GB), Driver 575.57.08, CUDA 12.9
 - **Go:** 1.25.5 at `/usr/local/go/bin/go`
-- **Code Location:** `~/k8s-mcp-agent`
+- **Code Location:** `~/k8s-gpu-mcp-server`
 
 ---
 
 ## FIRST TASK: Create Branch
 
 ```bash
-cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
 git checkout main && git pull
 git checkout -b feat/m2-nvml-extension
 ```
@@ -603,7 +603,7 @@ func (h *GPUHealthHandler) checkPerformance(ctx context.Context, device nvml.Dev
 ### Local Testing (Mock NVML)
 
 ```bash
-cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
 
 # Run unit tests
 make test
@@ -621,7 +621,7 @@ cat examples/gpu_health.json | ./bin/agent --nvml-mode=mock
 # SSH to GPU machine
 ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com
 
-cd ~/k8s-mcp-agent
+cd ~/k8s-gpu-mcp-server
 git fetch origin
 git checkout feat/m2-nvml-extension
 
@@ -766,7 +766,7 @@ gh pr create          # Create PR
 ### Remote Machine
 ```bash
 ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com
-cd ~/k8s-mcp-agent
+cd ~/k8s-gpu-mcp-server
 export PATH=/usr/local/go/bin:$PATH
 ```
 

--- a/docs/prompts/xid-error-analysis.md
+++ b/docs/prompts/xid-error-analysis.md
@@ -2,9 +2,9 @@
 
 ## PROJECT CONTEXT
 
-**Repository:** https://github.com/ArangoGutierrez/k8s-mcp-agent  
+**Repository:** https://github.com/ArangoGutierrez/k8s-gpu-mcp-server  
 **Current Branch:** `main`  
-**Workspace:** `/Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent`
+**Workspace:** `/Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server`
 
 ### Current State (Jan 3, 2026)
 - ✅ M1 Complete: MCP stdio server working, Mock NVML implemented
@@ -23,7 +23,7 @@
 - **SSH:** `ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com`
 - **GPU:** Tesla T4 (15GB), Driver 575.57.08, CUDA 12.9
 - **Go:** 1.25.5 at `/usr/local/go/bin/go`
-- **Code Location:** `~/k8s-mcp-agent`
+- **Code Location:** `~/k8s-gpu-mcp-server`
 - **Kubernetes:** v1.33.3 single node
 
 ---
@@ -199,8 +199,8 @@ Create `pkg/tools/analyze_xid.go`:
 package tools
 
 import (
-    "github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
-    "github.com/ArangoGutierrez/k8s-mcp-agent/pkg/xid"
+    "github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
+    "github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/xid"
     "github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -293,7 +293,7 @@ func (h *AnalyzeXIDHandler) Handle(
 
 In `pkg/mcp/server.go`, add to imports:
 ```go
-import "github.com/ArangoGutierrez/k8s-mcp-agent/pkg/xid"
+import "github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/xid"
 ```
 
 In `New()` function after gpu_inventory registration:
@@ -339,7 +339,7 @@ Create `examples/analyze_xid.json`:
 ### Local Testing (Mock dmesg)
 
 ```bash
-cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
 
 # Run unit tests
 make test
@@ -358,7 +358,7 @@ cat examples/analyze_xid.json | ./bin/agent --nvml-mode=mock
 ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com
 
 # Navigate to code
-cd ~/k8s-mcp-agent
+cd ~/k8s-gpu-mcp-server
 
 # Pull latest changes
 git fetch origin
@@ -434,7 +434,7 @@ Or if errors exist:
 
 ### Step 1: Create Branch and Structure
 ```bash
-cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-mcp-agent
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
 git checkout main && git pull
 git checkout -b feat/m2-xid-error-analysis
 
@@ -525,17 +525,17 @@ ls -lh bin/agent
 ```bash
 # Build on remote
 ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com \
-  "cd ~/k8s-mcp-agent && git pull && git checkout feat/m2-xid-error-analysis && \
+  "cd ~/k8s-gpu-mcp-server && git pull && git checkout feat/m2-xid-error-analysis && \
    export PATH=/usr/local/go/bin:\$PATH && go build -o bin/agent ./cmd/agent"
 
 # Check for XIDs
 ssh ... "sudo dmesg | grep -i xid"
 
 # Test tool
-ssh ... "cd ~/k8s-mcp-agent && cat examples/analyze_xid.json | ./bin/agent --nvml-mode=real"
+ssh ... "cd ~/k8s-gpu-mcp-server && cat examples/analyze_xid.json | ./bin/agent --nvml-mode=real"
 
 # Run integration tests
-ssh ... "cd ~/k8s-mcp-agent && go test -tags=integration -v ./pkg/xid/"
+ssh ... "cd ~/k8s-gpu-mcp-server && go test -tags=integration -v ./pkg/xid/"
 ```
 
 ### Step 9: Documentation
@@ -741,7 +741,7 @@ gh pr checks --watch  # Monitor CI
 ### Remote Machine
 ```bash
 ssh -i /Users/eduardoa/.ssh/cnt-ci.pem ubuntu@ec2-54-176-252-175.us-west-1.compute.amazonaws.com
-cd ~/k8s-mcp-agent
+cd ~/k8s-gpu-mcp-server
 export PATH=/usr/local/go/bin:$PATH
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start Guide
 
-Get started with `k8s-mcp-agent` in under 5 minutes.
+Get started with `k8s-gpu-mcp-server` in under 5 minutes.
 
 ## Prerequisites
 
@@ -15,17 +15,17 @@ Get started with `k8s-mcp-agent` in under 5 minutes.
 
 ```bash
 # Download latest release (coming in M4)
-curl -LO https://github.com/ArangoGutierrez/k8s-mcp-agent/releases/latest/download/agent-linux-amd64
+curl -LO https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/releases/latest/download/agent-linux-amd64
 chmod +x agent-linux-amd64
-mv agent-linux-amd64 /usr/local/bin/k8s-mcp-agent
+mv agent-linux-amd64 /usr/local/bin/k8s-gpu-mcp-server
 ```
 
 ### Option 2: Build from Source
 
 ```bash
 # Clone repository
-git clone https://github.com/ArangoGutierrez/k8s-mcp-agent.git
-cd k8s-mcp-agent
+git clone https://github.com/ArangoGutierrez/k8s-gpu-mcp-server.git
+cd k8s-gpu-mcp-server
 
 # Build agent
 make agent
@@ -38,7 +38,7 @@ make agent
 
 ```bash
 # Pull latest image (coming in M3)
-docker pull ghcr.io/arangogutierrez/k8s-mcp-agent:latest
+docker pull ghcr.io/arangogutierrez/k8s-gpu-mcp-server:latest
 ```
 
 ## Basic Usage
@@ -105,7 +105,7 @@ GPU access in Kubernetes requires one of:
 
 ```bash
 # Add the chart (if published) or use local path
-helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
+helm install k8s-gpu-mcp-server ./deployment/helm/k8s-gpu-mcp-server \
   --namespace gpu-diagnostics \
   --create-namespace
 
@@ -118,7 +118,7 @@ kubectl get pods -n gpu-diagnostics -o wide
 For clusters without RuntimeClass configured (e.g., cri-dockerd):
 
 ```bash
-helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
+helm install k8s-gpu-mcp-server ./deployment/helm/k8s-gpu-mcp-server \
   --namespace gpu-diagnostics \
   --create-namespace \
   --set gpu.runtimeClass.enabled=false \
@@ -134,7 +134,7 @@ helm install k8s-mcp-agent ./deployment/helm/k8s-mcp-agent \
 # Find agent pod on target node
 NODE_NAME=gpu-node-5
 POD=$(kubectl get pods -n gpu-diagnostics \
-  -l app.kubernetes.io/name=k8s-mcp-agent \
+  -l app.kubernetes.io/name=k8s-gpu-mcp-server \
   --field-selector spec.nodeName=$NODE_NAME \
   -o jsonpath='{.items[0].metadata.name}')
 
@@ -207,7 +207,7 @@ Once the agent is running, you can call these MCP tools:
 ```bash
 # 1. Connect to the problematic node
 kubectl debug node/gpu-node-5 \
-  --image=ghcr.io/arangogutierrez/k8s-mcp-agent:latest \
+  --image=ghcr.io/arangogutierrez/k8s-gpu-mcp-server:latest \
   --profile=sysadmin \
   -- /bin/bash
 
@@ -288,7 +288,7 @@ echo '{"jsonrpc":"2.0","method":"tools/call",...}' | ./bin/agent
 ## Getting Help
 
 - 📖 [Full Documentation](README.md)
-- 🐛 [Report Issues](https://github.com/ArangoGutierrez/k8s-mcp-agent/issues)
-- 💬 [Discussions](https://github.com/ArangoGutierrez/k8s-mcp-agent/discussions)
+- 🐛 [Report Issues](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues)
+- 💬 [Discussions](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/discussions)
 - 📧 Contact: [@ArangoGutierrez](https://github.com/ArangoGutierrez)
 

--- a/docs/reports/m1-completion.md
+++ b/docs/reports/m1-completion.md
@@ -7,7 +7,7 @@
 ## Executive Summary
 
 Milestone 1 has been successfully completed, establishing the foundational
-architecture for the k8s-mcp-agent project. All core deliverables have been
+architecture for the k8s-gpu-mcp-server project. All core deliverables have been
 implemented, tested, and documented.
 
 ## Deliverables
@@ -37,7 +37,7 @@ $ make agent
 ✓ Built bin/agent
 
 $ ./bin/agent --version
-k8s-mcp-agent version 0.1.0-alpha (commit 0051333...)
+k8s-gpu-mcp-server version 0.1.0-alpha (commit 0051333...)
 
 $ ./bin/agent --help
 Usage of ./bin/agent:
@@ -73,7 +73,7 @@ Usage of ./bin/agent:
 ```bash
 $ cat examples/echo_test.json | ./bin/agent
 {
-  "echo": "Hello from k8s-mcp-agent!",
+  "echo": "Hello from k8s-gpu-mcp-server!",
   "timestamp": "2026-01-03T12:00:00Z",
   "mode": "read-only"
 }
@@ -240,7 +240,7 @@ $ make all
 
 ```
 Package                                          Tests  Pass  Fail
-github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml   13    13     0
+github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml   13    13     0
 ```
 
 **Test Cases:**

--- a/docs/reports/m2-completion.md
+++ b/docs/reports/m2-completion.md
@@ -39,7 +39,7 @@ providing complete GPU diagnostics for AI/ML workload troubleshooting.
 **Verification:**
 ```bash
 $ make test
-ok  github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml  (20+ tests passing)
+ok  github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml  (20+ tests passing)
 ```
 
 ---
@@ -176,10 +176,10 @@ ok  github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml  (20+ tests passing)
 
 ```
 Package                                              Tests  Pass
-github.com/ArangoGutierrez/k8s-mcp-agent/pkg/mcp       7     7
-github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml     20    20
-github.com/ArangoGutierrez/k8s-mcp-agent/pkg/tools    40+   40+
-github.com/ArangoGutierrez/k8s-mcp-agent/pkg/xid      15    15
+github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/mcp       7     7
+github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml     20    20
+github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/tools    40+   40+
+github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/xid      15    15
 ```
 
 ### Integration Testing
@@ -276,7 +276,7 @@ All tools follow:
 
 ## Conclusion
 
-Milestone 2 has been completed **13 days ahead of schedule**. The k8s-mcp-agent
+Milestone 2 has been completed **13 days ahead of schedule**. The k8s-gpu-mcp-server
 now provides comprehensive GPU hardware introspection:
 
 - ✅ 16 NVML interface methods implemented

--- a/examples/echo_test.json
+++ b/examples/echo_test.json
@@ -4,7 +4,7 @@
   "params": {
     "name": "echo_test",
     "arguments": {
-      "message": "Hello from k8s-mcp-agent!"
+      "message": "Hello from k8s-gpu-mcp-server!"
     }
   },
   "id": 1

--- a/examples/test_mcp.sh
+++ b/examples/test_mcp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2026 k8s-mcp-agent contributors
+# Copyright 2026 k8s-gpu-mcp-server contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # Test script for MCP protocol validation
@@ -8,7 +8,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AGENT_BIN="${SCRIPT_DIR}/../bin/agent"
 
-echo "=== Testing k8s-mcp-agent MCP Protocol ==="
+echo "=== Testing k8s-gpu-mcp-server MCP Protocol ==="
 echo
 
 # Check if agent binary exists

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ArangoGutierrez/k8s-mcp-agent
+module github.com/ArangoGutierrez/k8s-gpu-mcp-server
 
 go 1.25
 

--- a/hack/init_github.sh
+++ b/hack/init_github.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # NVIDIA K8s MCP Agent - GitHub Repository Initialization Script
 # This script sets up labels, milestones, and initial issues for project governance.
 
-REPO="ArangoGutierrez/k8s-mcp-agent"
+REPO="ArangoGutierrez/k8s-gpu-mcp-server"
 
 echo "🚀 Initializing GitHub repository: ${REPO}"
 echo ""

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Package info provides build-time version information for the agent.

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Package mcp provides the MCP server implementation for stdio transport.
@@ -12,8 +12,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/tools"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/tools"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -54,7 +54,7 @@ func New(cfg Config) (*Server, error) {
 
 	// Create MCP server
 	mcpServer := server.NewMCPServer(
-		"k8s-mcp-agent",
+		"k8s-gpu-mcp-server",
 		cfg.Version,
 	)
 

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package mcp
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/nvml/interface.go
+++ b/pkg/nvml/interface.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Package nvml provides an abstraction layer over NVIDIA NVML library.

--- a/pkg/nvml/mock.go
+++ b/pkg/nvml/mock.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package nvml

--- a/pkg/nvml/mock_test.go
+++ b/pkg/nvml/mock_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package nvml

--- a/pkg/nvml/real.go
+++ b/pkg/nvml/real.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build cgo

--- a/pkg/nvml/real_stub.go
+++ b/pkg/nvml/real_stub.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !cgo

--- a/pkg/nvml/real_test.go
+++ b/pkg/nvml/real_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration && cgo

--- a/pkg/tools/analyze_xid.go
+++ b/pkg/tools/analyze_xid.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tools
@@ -10,8 +10,8 @@ import (
 	"log"
 	"strings"
 
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/xid"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/xid"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 

--- a/pkg/tools/analyze_xid_test.go
+++ b/pkg/tools/analyze_xid_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tools
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/xid"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/xid"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/tools/gpu_health.go
+++ b/pkg/tools/gpu_health.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tools
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 

--- a/pkg/tools/gpu_health_test.go
+++ b/pkg/tools/gpu_health_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tools
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/tools/gpu_inventory.go
+++ b/pkg/tools/gpu_inventory.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Package tools implements MCP tool handlers for GPU operations.
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 

--- a/pkg/tools/gpu_inventory_test.go
+++ b/pkg/tools/gpu_inventory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package tools
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/ArangoGutierrez/k8s-mcp-agent/pkg/nvml"
+	"github.com/ArangoGutierrez/k8s-gpu-mcp-server/pkg/nvml"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/xid/codes.go
+++ b/pkg/xid/codes.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // Package xid provides NVIDIA XID error code lookup and classification.

--- a/pkg/xid/codes_test.go
+++ b/pkg/xid/codes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package xid

--- a/pkg/xid/parser.go
+++ b/pkg/xid/parser.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package xid

--- a/pkg/xid/parser_test.go
+++ b/pkg/xid/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 k8s-mcp-agent contributors
+// Copyright 2026 k8s-gpu-mcp-server contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package xid

--- a/versions.mk
+++ b/versions.mk
@@ -1,4 +1,4 @@
-# Copyright 2026 k8s-mcp-agent contributors
+# Copyright 2026 k8s-gpu-mcp-server contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # Versions and tags


### PR DESCRIPTION
## Summary
Renames the project from `k8s-mcp-agent` to `k8s-gpu-mcp-server`.

## Changes
- ✅ Update `go.mod` module path
- ✅ Update all Go import statements (61 files)
- ✅ Update container image references
- ✅ Rename Helm chart directory
- ✅ Update documentation URLs
- ✅ Update binary name references
- ✅ All tests pass

## After Merge
After merging this PR, rename the GitHub repository:
```bash
gh repo rename k8s-gpu-mcp-server
```

Then update local remotes:
```bash
git remote set-url origin git@github.com:ArangoGutierrez/k8s-gpu-mcp-server.git
```

Closes #90