### PR TITLE
docs(prompts): add quick-win prompts for #100 and #87

### DIFF
--- a/docs/prompts/README.md
+++ b/docs/prompts/README.md
@@ -15,8 +15,11 @@ bugs, or completing other project work.
 
 | Prompt | Issue | Status | Description |
 |--------|-------|--------|-------------|
-| [http-sse-transport.md](http-sse-transport.md) | #71 | 🔴 P0-Blocker | HTTP/SSE transport for remote MCP access |
-| [npm-package-distribution.md](npm-package-distribution.md) | #74 | ✅ Done | npm package for one-liner installation |
+| [remove-echo-test.md](remove-echo-test.md) | #100 | 🟡 P2 | Remove echo_test tool from production |
+| [one-click-install-buttons.md](one-click-install-buttons.md) | #87 | 🟢 P3 | One-click install buttons for Cursor/VSCode |
+| [gateway-mode.md](gateway-mode.md) | #72 | ✅ Done | Gateway mode for multi-node clusters |
+| [gateway-tool-proxy.md](gateway-tool-proxy.md) | #98 | ✅ Done | Proxy all GPU tools via gateway |
+| [real-cluster-integration-testing.md](real-cluster-integration-testing.md) | - | ✅ Done | Integration testing guide |
 
 ## Template
 
@@ -28,6 +31,8 @@ Completed prompts are moved to `archive/` for reference:
 
 | Prompt | Related Issue/PR | Completed |
 |--------|-----------------|-----------|
+| http-sse-transport.md | #71, PR #93 | Jan 2026 |
+| npm-package-distribution.md | #74, PR #92 | Jan 2026 |
 | daemonset-manifests.md | PR #67 | Jan 2026 |
 | gpu-health-monitoring.md | Issue #7, M2 | Jan 2026 |
 | gpu-inventory-enhancement.md | Issue #5, M2 | Jan 2026 |

--- a/docs/prompts/one-click-install-buttons.md
+++ b/docs/prompts/one-click-install-buttons.md
@@ -1,0 +1,296 @@
+# One-Click Install Buttons for Cursor/VSCode
+
+## Issue Reference
+
+- **Issue:** [#87 - docs: One-click install buttons for Cursor/VSCode](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues/87)
+- **Priority:** P3-Low
+- **Labels:** kind/docs
+- **Milestone:** M3: Kubernetes Integration
+
+## Background
+
+Reference: `containers/kubernetes-mcp-server` has install buttons:
+
+```markdown
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?...)
+```
+
+One-click install buttons:
+- Reduce friction for new users
+- Improve adoption rates
+- Give professional appearance
+- Match other MCP servers' UX
+
+---
+
+## Objective
+
+Add one-click install badges to the README for easy MCP setup in Cursor, VS
+Code, and Claude Desktop.
+
+---
+
+## Step 0: Create Feature Branch
+
+> **⚠️ REQUIRED FIRST STEP - DO NOT SKIP**
+
+```bash
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
+git checkout main
+git pull origin main
+git checkout -b docs/one-click-install
+```
+
+---
+
+## Implementation Tasks
+
+### Task 1: Research Deep Link Format
+
+Understand the deep link format for each IDE.
+
+**Cursor deep link format:**
+```
+https://cursor.com/install-mcp?name=<name>&config=<base64-encoded-config>
+```
+
+**Config to encode:**
+```json
+{
+  "mcpServers": {
+    "k8s-gpu-mcp": {
+      "command": "npx",
+      "args": ["-y", "@arangogutierrez/k8s-gpu-mcp-server"]
+    }
+  }
+}
+```
+
+**VS Code format:**
+```
+vscode://anysphere.cursor-mcp/install?config=<base64>
+```
+
+**Acceptance criteria:**
+- [ ] Understand Cursor deep link format
+- [ ] Understand VS Code MCP extension format (if available)
+- [ ] Document the config structure
+
+> 💡 **Commit after completing this task**
+
+---
+
+### Task 2: Create Install Button Assets
+
+Create or source the badge images.
+
+**Options:**
+1. Use Cursor's official badge SVG (if available)
+2. Use shields.io custom badges
+3. Create simple markdown-based buttons
+
+**Shields.io examples:**
+```markdown
+![Install in Cursor](https://img.shields.io/badge/Install-Cursor-blue?logo=cursor&logoColor=white)
+![Install in VS Code](https://img.shields.io/badge/Install-VS%20Code-007ACC?logo=visualstudiocode&logoColor=white)
+```
+
+**Files to create:**
+- `docs/images/install-cursor.svg` (optional - can use shields.io)
+
+**Acceptance criteria:**
+- [ ] Badge style decided (shields.io or custom)
+- [ ] Consistent with project branding
+
+> 💡 **Commit after completing this task**
+
+---
+
+### Task 3: Generate Base64 Config
+
+Create the base64-encoded configuration for deep links.
+
+**Script to generate:**
+```bash
+# For npx installation
+echo '{"mcpServers":{"k8s-gpu-mcp":{"command":"npx","args":["-y","@arangogutierrez/k8s-gpu-mcp-server"]}}}' | base64
+
+# For kubectl exec (advanced)
+echo '{"mcpServers":{"k8s-gpu-mcp":{"command":"kubectl","args":["exec","-i","deploy/gpu-mcp-gateway","-n","gpu-diagnostics","--","/agent"]}}}' | base64
+```
+
+**Acceptance criteria:**
+- [ ] Base64 config generated for npx method
+- [ ] Base64 config generated for kubectl method (optional)
+- [ ] Configs tested and working
+
+> 💡 **Commit after completing this task**
+
+---
+
+### Task 4: Update README with Install Section
+
+Add a new "Quick Install" section to the README.
+
+**Files to modify:**
+- `README.md` - Add install buttons section
+
+**Proposed README addition:**
+
+```markdown
+## Quick Install
+
+### One-Click Install
+
+[![Install in Cursor](https://img.shields.io/badge/Install-Cursor-black?logo=data:image/svg+xml;base64,...&logoColor=white)](https://cursor.com/install-mcp?name=k8s-gpu-mcp&config=eyJtY3BTZXJ2ZXJzIjp7Ims4cy1ncHUtbWNwIjp7ImNvbW1hbmQiOiJucHgiLCJhcmdzIjpbIi15IiwiQGFyYW5nb2d1dGllcnJlei9rOHMtZ3B1LW1jcC1zZXJ2ZXIiXX19fQ==)
+
+### Manual Installation
+
+<details>
+<summary>Cursor / VS Code</summary>
+
+Add to `~/.cursor/mcp.json`:
+```json
+{
+  "mcpServers": {
+    "k8s-gpu-mcp": {
+      "command": "npx",
+      "args": ["-y", "@arangogutierrez/k8s-gpu-mcp-server"]
+    }
+  }
+}
+```
+</details>
+
+<details>
+<summary>Claude Desktop</summary>
+
+Add to Claude Desktop config:
+```json
+{
+  "mcpServers": {
+    "k8s-gpu-mcp": {
+      "command": "npx",
+      "args": ["-y", "@arangogutierrez/k8s-gpu-mcp-server"]
+    }
+  }
+}
+```
+</details>
+```
+
+**Acceptance criteria:**
+- [ ] Install button with working deep link
+- [ ] Manual installation instructions in collapsible sections
+- [ ] Both Cursor and Claude Desktop covered
+- [ ] Instructions are copy-paste ready
+
+> 💡 **Commit after completing this task**
+
+---
+
+### Task 5: Test Deep Links
+
+Verify the deep links work correctly.
+
+**Testing steps:**
+1. Click the Cursor install button
+2. Verify it opens Cursor with the MCP config dialog
+3. Verify the config is correct
+4. Test the MCP connection works
+
+**Acceptance criteria:**
+- [ ] Cursor deep link opens correctly
+- [ ] Config is properly applied
+- [ ] MCP server connects successfully
+
+> 💡 **Commit after completing this task**
+
+---
+
+## Testing Requirements
+
+### Link Validation
+
+```bash
+# Decode and verify the config
+echo "eyJtY3BTZXJ2ZXJzIjp7Ims4cy1ncHUtbWNwIjp7ImNvbW1hbmQiOiJucHgiLCJhcmdzIjpbIi15IiwiQGFyYW5nb2d1dGllcnJlei9rOHMtZ3B1LW1jcC1zZXJ2ZXIiXX19fQ==" | base64 -d | jq .
+```
+
+### Manual Testing
+
+1. Open the README in GitHub
+2. Click the install button
+3. Verify Cursor opens with correct config
+
+---
+
+## Pre-Commit Checklist
+
+- [ ] Links are valid and working
+- [ ] README renders correctly on GitHub
+- [ ] Images load (if using custom images)
+- [ ] No broken markdown
+
+---
+
+## Commit and Push
+
+### Commits
+
+```bash
+git commit -s -S -m "docs: add one-click install button for Cursor"
+git commit -s -S -m "docs: add manual installation instructions"
+```
+
+### Push
+
+```bash
+git push -u origin docs/one-click-install
+```
+
+---
+
+## Create Pull Request
+
+```bash
+gh pr create \
+  --title "docs: add one-click install buttons for Cursor/VSCode" \
+  --body "Fixes #87
+
+## Summary
+Adds one-click install buttons to README for easy MCP setup.
+
+## Changes
+- Add Cursor install deep link button
+- Add collapsible manual installation sections
+- Cover Cursor, VS Code, and Claude Desktop
+
+## Screenshots
+[Add screenshot of the install button]
+
+## Testing
+- [x] Deep link opens Cursor correctly
+- [x] Config is properly formatted
+- [x] README renders correctly on GitHub" \
+  --label "kind/docs"
+```
+
+---
+
+## Quick Reference
+
+**Estimated Time:** 30-45 minutes
+
+**Complexity:** Easy - documentation only
+
+**Files Changed:**
+- `README.md`
+- `docs/images/` (optional)
+
+**Dependencies:**
+- NPM package must be published (`@arangogutierrez/k8s-gpu-mcp-server`)
+
+---
+
+**Reply "GO" when ready to start implementation.** 🚀

--- a/docs/prompts/remove-echo-test.md
+++ b/docs/prompts/remove-echo-test.md
@@ -1,0 +1,227 @@
+# Remove echo_test Tool from Production Builds
+
+## Issue Reference
+
+- **Issue:** [#100 - Remove echo_test tool from production builds](https://github.com/ArangoGutierrez/k8s-gpu-mcp-server/issues/100)
+- **Priority:** P2-Medium
+- **Labels:** enhancement, good first issue
+- **Milestone:** M3: Kubernetes Integration
+
+## Background
+
+The `echo_test` tool was useful during development but has no value in
+production. Every MCP tool is injected into user prompts, consuming tokens
+unnecessarily:
+
+- Tool definition: ~50-100 tokens per conversation
+- Multiplied across all users = significant waste
+- Creates noise in tool listings
+
+The health endpoints (`/healthz`, `/readyz`) and actual GPU tools provide
+sufficient validation for production use.
+
+---
+
+## Objective
+
+Remove the `echo_test` tool from the default MCP server registration to reduce
+token overhead in production.
+
+---
+
+## Step 0: Create Feature Branch
+
+> **⚠️ REQUIRED FIRST STEP - DO NOT SKIP**
+
+```bash
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
+git checkout main
+git pull origin main
+git checkout -b chore/remove-echo-test
+```
+
+---
+
+## Implementation Tasks
+
+### Task 1: Remove echo_test Registration
+
+Remove the `echo_test` tool registration from the MCP server initialization.
+
+**Files to modify:**
+- `pkg/mcp/server.go` - Remove echo_test tool registration
+
+**Current code to remove:**
+
+```go
+// Remove this line from NewServer()
+mcpServer.AddTool(echoTool, s.handleEchoTest)
+```
+
+**Acceptance criteria:**
+- [ ] `echo_test` tool is not registered in the MCP server
+- [ ] Server starts without errors
+
+> 💡 **Commit after completing this task**
+
+---
+
+### Task 2: Remove echo_test Handler and Tool Definition
+
+Remove the handler function and tool definition for echo_test.
+
+**Files to modify:**
+- `pkg/mcp/server.go` - Remove `handleEchoTest` function and `echoTool` var
+
+**Code to remove:**
+
+```go
+// Remove the echoTool variable definition
+var echoTool = mcp.NewTool(
+    "echo_test",
+    // ...
+)
+
+// Remove the handler function
+func (s *Server) handleEchoTest(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+    // ...
+}
+```
+
+**Acceptance criteria:**
+- [ ] `echoTool` variable removed
+- [ ] `handleEchoTest` function removed
+- [ ] No dead code remaining
+
+> 💡 **Commit after completing this task**
+
+---
+
+### Task 3: Remove echo_test from Tests
+
+Update or remove any tests that reference echo_test.
+
+**Files to check:**
+- `pkg/mcp/server_test.go` - Remove echo_test test cases
+- `examples/echo_test.json` - Delete example file
+
+**Acceptance criteria:**
+- [ ] No test references to echo_test
+- [ ] `examples/echo_test.json` deleted
+- [ ] All tests pass
+
+> 💡 **Commit after completing this task**
+
+---
+
+### Task 4: Update Documentation
+
+Remove references to echo_test from documentation.
+
+**Files to check:**
+- `README.md` - Remove any echo_test mentions
+- `docs/mcp-usage.md` - Remove echo_test examples
+
+**Acceptance criteria:**
+- [ ] No documentation references to echo_test
+- [ ] Examples updated to use real GPU tools
+
+> 💡 **Commit after completing this task**
+
+---
+
+## Testing Requirements
+
+### Local Testing
+
+```bash
+cd /Users/eduardoa/src/github/ArangoGutierrez/k8s-gpu-mcp-server
+
+# Run all checks
+make all
+
+# Verify echo_test is not in tool list
+./bin/agent --nvml-mode=mock < examples/initialize.json 2>/dev/null | \
+  grep -c "echo_test" || echo "✅ echo_test not found"
+
+# Verify other tools still work
+./bin/agent --nvml-mode=mock < examples/gpu_inventory.json
+```
+
+---
+
+## Pre-Commit Checklist
+
+```bash
+make fmt
+make lint
+make test
+make all
+```
+
+- [ ] `go fmt ./...` - Code formatted
+- [ ] `go vet ./...` - No vet warnings
+- [ ] `golangci-lint run` - Linter passes
+- [ ] `go test ./... -count=1` - All tests pass
+
+---
+
+## Commit and Push
+
+### Commits
+
+```bash
+git commit -s -S -m "chore(mcp): remove echo_test tool registration"
+git commit -s -S -m "chore(mcp): remove echo_test handler and definition"
+git commit -s -S -m "test(mcp): remove echo_test test cases"
+git commit -s -S -m "docs: remove echo_test references"
+```
+
+### Push
+
+```bash
+git push -u origin chore/remove-echo-test
+```
+
+---
+
+## Create Pull Request
+
+```bash
+gh pr create \
+  --title "chore(mcp): remove echo_test tool from production" \
+  --body "Fixes #100
+
+## Summary
+Removes the echo_test tool to reduce token overhead in production.
+
+## Changes
+- Remove echo_test tool registration
+- Remove handler function and tool definition
+- Remove test cases and example file
+- Update documentation
+
+## Testing
+- [x] make all passes
+- [x] Tool list no longer includes echo_test
+- [x] GPU tools still work correctly" \
+  --label "enhancement"
+```
+
+---
+
+## Quick Reference
+
+**Estimated Time:** 30 minutes
+
+**Complexity:** Easy - straightforward removal
+
+**Files Changed:**
+- `pkg/mcp/server.go`
+- `pkg/mcp/server_test.go`
+- `examples/echo_test.json` (delete)
+- Documentation files
+
+---
+
+**Reply "GO" when ready to start implementation.** 🚀


### PR DESCRIPTION
## Summary

Adds implementation prompts for two quick-win issues.

## New Prompts

### 1. `remove-echo-test.md` (Issue #100)
- Remove `echo_test` tool from production builds
- Reduces token overhead in user prompts
- Estimated time: 30 minutes
- Complexity: Easy

### 2. `one-click-install-buttons.md` (Issue #87)  
- Add one-click install buttons to README
- Cursor deep link integration
- Estimated time: 30-45 minutes
- Complexity: Easy (docs only)

## Changes
- Add `docs/prompts/remove-echo-test.md`
- Add `docs/prompts/one-click-install-buttons.md`
- Update `docs/prompts/README.md` with active prompts table

## Checklist
- [x] Prompts follow TEMPLATE.md structure
- [x] README updated with new prompts
- [x] Archived completed prompts listed