### PR TITLE
fix(gateway): align HTTP and exec timeouts to prevent race conditions

### DIFF
--- a/deployment/helm/k8s-gpu-mcp-server/templates/gateway-deployment.yaml
+++ b/deployment/helm/k8s-gpu-mcp-server/templates/gateway-deployment.yaml
@@ -42,6 +42,9 @@ spec:
         - "--port={{ .Values.gateway.port }}"
         - "--namespace={{ include "k8s-gpu-mcp-server.namespace" . }}"
         - "--mode={{ .Values.agent.mode }}"
+        env:
+        - name: EXEC_TIMEOUT
+          value: {{ .Values.gateway.execTimeout | default "60s" | quote }}
         ports:
         - name: http
           containerPort: {{ .Values.gateway.port }}

--- a/deployment/helm/k8s-gpu-mcp-server/values.yaml
+++ b/deployment/helm/k8s-gpu-mcp-server/values.yaml
@@ -184,6 +184,10 @@ gateway:
   # -- Gateway HTTP port
   port: 8080
 
+  # -- Timeout for kubectl exec operations to agent pods.
+  # Must be less than HTTP WriteTimeout (90s) to prevent race conditions.
+  execTimeout: "60s"
+
   # -- Gateway service configuration
   service:
     # -- Service type for gateway


### PR DESCRIPTION
Fixes #113

## Summary

Aligns HTTP WriteTimeout (90s) with exec timeout (60s) to prevent race conditions that cause 'socket hang up' errors. Makes exec timeout configurable via EXEC_TIMEOUT environment variable.

## Changes

- Increase HTTP WriteTimeout from 30s to 90s
- Increase default exec timeout from 30s to 60s
- Add EXEC_TIMEOUT env var support for runtime configuration
- Add timing telemetry for debugging slow exec operations
- Update Helm chart with gateway.execTimeout value
- Add unit tests for exec timeout configuration

## Timeline Fix

**Before (race condition):**
```
T+0s:    HTTP request received
T+0.1s:  Start parallel exec to nodes
T+30s:   Exec timeout fires on all nodes
T+30s:   HTTP write timeout fires simultaneously
T+30s:   "socket hang up" - connection closed before response
```

**After (30s buffer):**
```
T+0s:    HTTP request received
T+0.1s:  Start parallel exec to nodes
T+60s:   Exec timeout fires (if slow)
T+60.1s: Response marshaled
T+60.2s: Response written
T+90s:   HTTP timeout (never reached)
```

## Testing

- [x] Unit tests pass
- [x] `make fmt && make lint && make test` passes
- [ ] Manual E2E test with real cluster

## Configuration

The exec timeout can now be configured at deploy time:

```yaml
gateway:
  execTimeout: "60s"  # default
```

Or via environment variable on existing deployments:

```bash
kubectl set env deployment/gpu-mcp-gateway EXEC_TIMEOUT=45s -n gpu-diagnostics
```

## Related

- Parent epic: #112
- Analysis: docs/reports/e2e-failure-analysis.md