### PR TITLE
feat(agent): enable HTTP transport as default for DaemonSet agents

### DIFF
--- a/deployment/helm/k8s-gpu-mcp-server/values.yaml
+++ b/deployment/helm/k8s-gpu-mcp-server/values.yaml
@@ -118,13 +118,15 @@ securityContext:
       - SYSLOG
 
 # Resource limits
+# Note: HTTP mode requires more baseline memory since agent stays resident
+# Oneshot/stdio mode has lower baseline but higher peak during requests
 resources:
   requests:
-    cpu: 1m
-    memory: 10Mi
+    cpu: 10m
+    memory: 32Mi
   limits:
     cpu: 100m
-    memory: 50Mi
+    memory: 128Mi
 
 # Pod annotations
 podAnnotations: {}
@@ -142,11 +144,23 @@ updateStrategy:
     maxUnavailable: 1
 
 # Transport configuration
+#
+# HTTP Mode (default, recommended for production):
+#   - Agent runs as persistent HTTP server
+#   - NVML initialized once at startup (~50-100ms)
+#   - Per-request latency: 12-57ms
+#   - Memory: constant ~15-20MB
+#   - Use case: Gateway routing, high-frequency queries
+#
+# Stdio Mode (legacy, for debugging):
+#   - Agent spawned per kubectl exec
+#   - NVML initialized per request
+#   - Per-request latency: 130-290ms
+#   - Memory: spiky (5MB idle → 200MB peak)
+#   - Use case: Direct kubectl debugging, SRE access
 transport:
-  # -- Transport mode: stdio or http
-  # stdio: Uses kubectl exec for interaction (default)
-  # http: Exposes HTTP endpoint for MCP access
-  mode: stdio
+  # -- Transport mode: http (recommended) or stdio (legacy)
+  mode: http
 
   # HTTP mode settings (only used if mode: http)
   http:
@@ -157,8 +171,9 @@ transport:
 
 # Service configuration (for HTTP mode)
 service:
-  # -- Enable service (required for HTTP mode)
-  enabled: false
+  # -- Enable service for agent pods (should be enabled when transport.mode=http)
+  # Required for gateway to discover agent endpoints
+  enabled: true
   # -- Service type
   type: ClusterIP
   # -- Service port

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -325,3 +325,54 @@ func TestDefaultExecTimeout_Value(t *testing.T) {
 	// Verify the default timeout is 60 seconds as per the fix
 	assert.Equal(t, 60*time.Second, DefaultExecTimeout)
 }
+
+func TestGPUNode_GetAgentHTTPEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     GPUNode
+		expected string
+	}{
+		{
+			name: "pod with IP",
+			node: GPUNode{
+				Name:    "gpu-node-1",
+				PodName: "gpu-agent-abc123",
+				PodIP:   "10.0.0.5",
+				Ready:   true,
+			},
+			expected: "http://10.0.0.5:8080",
+		},
+		{
+			name: "pod without IP",
+			node: GPUNode{
+				Name:    "gpu-node-2",
+				PodName: "gpu-agent-pending",
+				PodIP:   "",
+				Ready:   false,
+			},
+			expected: "",
+		},
+		{
+			name: "pod with IPv6",
+			node: GPUNode{
+				Name:    "gpu-node-3",
+				PodName: "gpu-agent-ipv6",
+				PodIP:   "fd00::1",
+				Ready:   true,
+			},
+			expected: "http://[fd00::1]:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.node.GetAgentHTTPEndpoint()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAgentHTTPPort(t *testing.T) {
+	// Verify the port constant matches the Helm default
+	assert.Equal(t, 8080, AgentHTTPPort)
+}


### PR DESCRIPTION
Fixes #114

## Summary

Changes the default transport mode from `stdio` to `http` so DaemonSet agents run as persistent HTTP servers with NVML initialized once at startup.

## Changes

- Change default `transport.mode` from `stdio` to `http`
- Enable service by default for agent pods
- Add `GetAgentHTTPEndpoint()` helper method to GPUNode
- Increase default resource limits for HTTP mode (128Mi memory)
- Document transport mode trade-offs in values.yaml

## Performance Impact

| Metric | Stdio (before) | HTTP (after) | Improvement |
|--------|----------------|--------------|-------------|
| Per-request latency | 130-290ms | 12-57ms | **80%** |
| NVML init | Per request | Once at startup | **Eliminated** |
| Memory pattern | Spiky | Constant | Stable |

## Testing

- [x] Unit tests pass
- [x] Helm template renders correctly for HTTP mode
- [x] Helm template renders correctly for stdio fallback
- [x] `make all` passes (fmt, lint, vet, test)

## Backward Compatibility

Stdio mode remains available via `transport.mode: stdio` for debugging and SRE access via kubectl exec.

## Related

- Parent epic: #112
- Blocks: #115 (Gateway HTTP routing)