### PR TITLE
fix(tools): add context cancellation and improve code quality

### DIFF
--- a/pkg/tools/pod_gpu_allocation.go
+++ b/pkg/tools/pod_gpu_allocation.go
@@ -111,6 +111,16 @@ func (h *PodGPUAllocationHandler) Handle(
 	var totalGPUs int64
 
 	for _, pod := range pods.Items {
+		// Check for context cancellation
+		select {
+		case <-ctx.Done():
+			log.Printf(`{"level":"info","msg":"context cancelled ` +
+				`during pod enumeration"}`)
+			return mcp.NewToolResultError(
+				fmt.Sprintf("operation cancelled: %s", ctx.Err())), nil
+		default:
+		}
+
 		// Client-side node filter (FieldSelector backup for fake clients)
 		if pod.Spec.NodeName != nodeName {
 			continue


### PR DESCRIPTION
## Summary

Follow-up fixes for M3 Kubernetes tools based on code review.

## Changes

### 1. Context Cancellation Checks
- **pod_gpu_allocation.go**: Added cancellation check in pod iteration loop
- **describe_gpu_node.go**: Added cancellation check in `getPodsSummary` loop

This ensures graceful termination of long-running operations when context is cancelled.

### 2. Client-Side Node Filtering
- Added backup node filter in `getPodsSummary` for fake clientset compatibility
- Matches the pattern already used in `pod_gpu_allocation.go`

### 3. Named Constants for Health Thresholds
Replaced magic numbers with documented constants:
- `healthyThreshold = 90`: Minimum avg score for "healthy" status
- `degradedThreshold = 70`: Minimum avg score for "degraded" status

## Testing

- [x] All existing tests pass
- [x] `make all` succeeds
- [x] No linter issues

## Related

Follow-up to PR #128